### PR TITLE
feat(bank-transactions): add note functionality to bank transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ sqlite.db
 *.db-wal
 
 data/
+
+.playwright-cli

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,56 +14,23 @@ bun --bun run dev      # Start dev server at localhost:4321
 bun run build          # Build for production
 bun --bun run preview  # Preview production build
 
-# Database
-bun run db:generate  # Generate Drizzle migrations from schema - never run this directly
-bun run db:migrate   # Run database migrations - never run this directly
+# Database - DO NOT RUN THESE! THIS IS DONE BY THE USER ONLY.
+bun run db:generate  # Generate Drizzle migrations from schema
+bun run db:migrate   # Run database migrations
 
 # Code Quality
 bun run lint --type-aware  # Run OxLint
 bun run astro check        # Astro project check
 ```
 
-## Architecture
-
-### Tech Stack
-
-- **Astro 5** - SSR framework with Node adapter (standalone mode)
-- **Vue 3** - Interactive components with `<script setup>`
-- **Better Auth** - Authentication with passkey support
-- **Drizzle ORM** - SQLite database with WAL mode
-- **Tailwind CSS 4** - CSS-first syntax with `@theme` blocks
-- **Reka UI** - Headless component primitives (shadcn-vue style)
-
-### Key Directories
-
-- `src/pages/` - Astro file-based routing (SSR)
-- `src/components/ui/` - shadcn-vue style UI components
-- `src/db/schema/` - Drizzle schema definitions
-- `src/lib/` - Auth configuration and utilities
-- `scripts/` - CLI scripts (migrations, user management)
-- `drizzle`- Never touch this folder - auto-generated Drizzle files
-
 ### Authentication Flow
 
 - Middleware (`src/middleware.ts`) protects all routes except `/login` and `/api/auth/*`
-- Better Auth handles sessions via `src/lib/auth.ts` (server) and `src/lib/auth-client.ts` (client)
-- Supports email/password + passkeys (WebAuthn)
 - **No per-user data scoping** — all authenticated users share access to all data. Do not introduce user-based authorization checks or data filtering.
 
 ### Component Patterns
 
 - Always prefer installing pre-built components from shadcn-vue than creating new base compoenents yourself. Use the shadcn-vue MCP server to look up existing components and see how they are used and configured.
-- All components use TypeScript with strict typing
-
-## Environment Variables
-
-Required in `.env` (see `.env.example`):
-
-- `DB_FILE_NAME` - SQLite database path
-- `BETTER_AUTH_SECRET` - 32-byte base64 secret
-- `BETTER_AUTH_URL` - Auth callback URL
-- `PASSKEY_RP_ID` - WebAuthn relying party ID
-- `PASSKEY_ORIGIN` - WebAuthn origin
 
 ## Path Alias
 
@@ -71,7 +38,7 @@ Required in `.env` (see `.env.example`):
 
 ## Formatting & checks
 
-- After applying changes, always run the linter and astro check
+- After applying changes, always run the linter `bun run lint --type-aware` and `bun run astro check`
 - If Vue.js components were changed, ensure that the TypeScript types are correct by running `bunx vue-tsc --noEmit`
 - After final changes, run the `bunx prettier --write` on changed files to ensure consistent formatting
 - always use german umlaute for user facing UI texts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,10 @@ bun run astro check        # Astro project check
 
 - Always prefer installing pre-built components from shadcn-vue than creating new base compoenents yourself. Use the shadcn-vue MCP server to look up existing components and see how they are used and configured.
 
+### reka-ui Component Props (shadcn-vue)
+
+shadcn-vue components are based on reka-ui v2. These components use `modelValue` / `update:modelValue` — **not** HTML-native names like `checked`, `selected`, or `value`. When using these components, always use the `modelValue` prop and `update:modelValue` event for two-way binding.
+
 ## Path Alias
 
 `@/*` maps to `./src/*` (configured in tsconfig.json)

--- a/drizzle/0010_early_doctor_faustus.sql
+++ b/drizzle/0010_early_doctor_faustus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `bank_transaction` ADD `note` text;

--- a/drizzle/0011_yielding_manta.sql
+++ b/drizzle/0011_yielding_manta.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `bank_transaction` ADD `is_archived` integer DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE INDEX `bankTransaction_isArchived_idx` ON `bank_transaction` (`is_archived`);

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,2230 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4065db33-10f8-45cc-9955-cd892fab17d1",
+  "prevId": "e89e2f42-c420-4194-80f0-24238f66ef53",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "twoFactor_userId_idx": {
+          "name": "twoFactor_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bank_transaction": {
+      "name": "bank_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_import_id": {
+          "name": "first_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_import_id": {
+          "name": "last_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_transaction_id": {
+          "name": "external_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_date": {
+          "name": "booking_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'EUR'"
+        },
+        "original_amount_cents": {
+          "name": "original_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_currency": {
+          "name": "original_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "counterparty": {
+          "name": "counterparty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_text": {
+          "name": "booking_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "balance_after_cents": {
+          "name": "balance_after_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "balance_currency": {
+          "name": "balance_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cardholder": {
+          "name": "cardholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_data_json": {
+          "name": "raw_data_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_assignment": {
+          "name": "plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "import_seen_count": {
+          "name": "import_seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bankTransaction_sourceId_dedupeKey_idx": {
+          "name": "bankTransaction_sourceId_dedupeKey_idx",
+          "columns": [
+            "source_id",
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "bankTransaction_bookingDate_idx": {
+          "name": "bankTransaction_bookingDate_idx",
+          "columns": [
+            "booking_date"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_planId_idx": {
+          "name": "bankTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_status_idx": {
+          "name": "bankTransaction_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_externalTransactionId_idx": {
+          "name": "bankTransaction_externalTransactionId_idx",
+          "columns": [
+            "external_transaction_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bank_transaction_source_id_import_source_id_fk": {
+          "name": "bank_transaction_source_id_import_source_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_first_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_first_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "first_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_last_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_last_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "last_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_plan_id_plan_id_fk": {
+          "name": "bank_transaction_plan_id_plan_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category": {
+      "name": "category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "category_name_idx": {
+          "name": "category_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "category_slug_idx": {
+          "name": "category_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_source": {
+      "name": "import_source",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_label": {
+          "name": "account_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_identifier": {
+          "name": "account_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_plan_assignment": {
+          "name": "default_plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto_month'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "importSource_preset_idx": {
+          "name": "importSource_preset_idx",
+          "columns": [
+            "preset"
+          ],
+          "isUnique": false
+        },
+        "importSource_isActive_idx": {
+          "name": "importSource_isActive_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kassensturz_dismissal": {
+      "name": "kassensturz_dismissal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_transaction_id": {
+          "name": "bank_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed_by_user_id": {
+          "name": "dismissed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kassensturzDismissal_bankTx_plan_idx": {
+          "name": "kassensturzDismissal_bankTx_plan_idx",
+          "columns": [
+            "bank_transaction_id",
+            "plan_id"
+          ],
+          "isUnique": true
+        },
+        "kassensturzDismissal_planId_idx": {
+          "name": "kassensturzDismissal_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "kassensturz_dismissal_bank_transaction_id_bank_transaction_id_fk": {
+          "name": "kassensturz_dismissal_bank_transaction_id_bank_transaction_id_fk",
+          "tableFrom": "kassensturz_dismissal",
+          "tableTo": "bank_transaction",
+          "columnsFrom": [
+            "bank_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_dismissal_plan_id_plan_id_fk": {
+          "name": "kassensturz_dismissal_plan_id_plan_id_fk",
+          "tableFrom": "kassensturz_dismissal",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_dismissal_dismissed_by_user_id_user_id_fk": {
+          "name": "kassensturz_dismissal_dismissed_by_user_id_user_id_fk",
+          "tableFrom": "kassensturz_dismissal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "dismissed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kassensturz_manual_entry": {
+      "name": "kassensturz_manual_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "planned_transaction_id": {
+          "name": "planned_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kassensturzManualEntry_planId_idx": {
+          "name": "kassensturzManualEntry_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "kassensturzManualEntry_plannedTransactionId_idx": {
+          "name": "kassensturzManualEntry_plannedTransactionId_idx",
+          "columns": [
+            "planned_transaction_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "kassensturz_manual_entry_plan_id_plan_id_fk": {
+          "name": "kassensturz_manual_entry_plan_id_plan_id_fk",
+          "tableFrom": "kassensturz_manual_entry",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_manual_entry_planned_transaction_id_planned_transaction_id_fk": {
+          "name": "kassensturz_manual_entry_planned_transaction_id_planned_transaction_id_fk",
+          "tableFrom": "kassensturz_manual_entry",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "planned_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kassensturz_manual_entry_created_by_user_id_user_id_fk": {
+          "name": "kassensturz_manual_entry_created_by_user_id_user_id_fk",
+          "tableFrom": "kassensturz_manual_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kassensturz_match_rule": {
+      "name": "kassensturz_match_rule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "merchant_fingerprint": {
+          "name": "merchant_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_planned_name_normalized": {
+          "name": "target_planned_name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_category_id": {
+          "name": "target_category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_amount_cents": {
+          "name": "avg_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_tolerance_cents": {
+          "name": "amount_tolerance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confirm_count": {
+          "name": "confirm_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kassensturzMatchRule_source_fingerprint_target_idx": {
+          "name": "kassensturzMatchRule_source_fingerprint_target_idx",
+          "columns": [
+            "source_id",
+            "direction",
+            "merchant_fingerprint",
+            "target_planned_name_normalized"
+          ],
+          "isUnique": true
+        },
+        "kassensturzMatchRule_lookup_idx": {
+          "name": "kassensturzMatchRule_lookup_idx",
+          "columns": [
+            "source_id",
+            "direction",
+            "merchant_fingerprint",
+            "active"
+          ],
+          "isUnique": false
+        },
+        "kassensturzMatchRule_targetName_idx": {
+          "name": "kassensturzMatchRule_targetName_idx",
+          "columns": [
+            "target_planned_name_normalized"
+          ],
+          "isUnique": false
+        },
+        "kassensturzMatchRule_category_idx": {
+          "name": "kassensturzMatchRule_category_idx",
+          "columns": [
+            "target_category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "kassensturz_match_rule_source_id_import_source_id_fk": {
+          "name": "kassensturz_match_rule_source_id_import_source_id_fk",
+          "tableFrom": "kassensturz_match_rule",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_match_rule_target_category_id_category_id_fk": {
+          "name": "kassensturz_match_rule_target_category_id_category_id_fk",
+          "tableFrom": "kassensturz_match_rule",
+          "tableTo": "category",
+          "columnsFrom": [
+            "target_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan": {
+      "name": "plan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plan_date_idx": {
+          "name": "plan_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "planned_transaction": {
+      "name": "planned_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_done": {
+          "name": "is_done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plannedTransaction_planId_idx": {
+          "name": "plannedTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_userId_idx": {
+          "name": "plannedTransaction_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_dueDate_idx": {
+          "name": "plannedTransaction_dueDate_idx",
+          "columns": [
+            "due_date"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_categoryId_idx": {
+          "name": "plannedTransaction_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_type_idx": {
+          "name": "plannedTransaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "planned_transaction_plan_id_plan_id_fk": {
+          "name": "planned_transaction_plan_id_plan_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_user_id_user_id_fk": {
+          "name": "planned_transaction_user_id_user_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_category_id_category_id_fk": {
+          "name": "planned_transaction_category_id_category_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "statement_import": {
+      "name": "statement_import",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_sha256": {
+          "name": "file_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preview_count": {
+          "name": "preview_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "statementImport_sourceId_idx": {
+          "name": "statementImport_sourceId_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "statementImport_fileSha256_idx": {
+          "name": "statementImport_fileSha256_idx",
+          "columns": [
+            "file_sha256"
+          ],
+          "isUnique": false
+        },
+        "statementImport_createdAt_idx": {
+          "name": "statementImport_createdAt_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "statement_import_source_id_import_source_id_fk": {
+          "name": "statement_import_source_id_import_source_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_import_triggered_by_user_id_user_id_fk": {
+          "name": "statement_import_triggered_by_user_id_user_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_preset": {
+      "name": "transaction_preset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'einmalig'"
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionPreset_userId_idx": {
+          "name": "transactionPreset_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_categoryId_idx": {
+          "name": "transactionPreset_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_type_idx": {
+          "name": "transactionPreset_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_recurrence_idx": {
+          "name": "transactionPreset_recurrence_idx",
+          "columns": [
+            "recurrence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_preset_user_id_user_id_fk": {
+          "name": "transaction_preset_user_id_user_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_preset_category_id_category_id_fk": {
+          "name": "transaction_preset_category_id_category_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_reconciliation": {
+      "name": "transaction_reconciliation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_transaction_id": {
+          "name": "bank_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "planned_transaction_id": {
+          "name": "planned_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_at": {
+          "name": "matched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_by_user_id": {
+          "name": "matched_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionReconciliation_bankTransactionId_idx": {
+          "name": "transactionReconciliation_bankTransactionId_idx",
+          "columns": [
+            "bank_transaction_id"
+          ],
+          "isUnique": true
+        },
+        "transactionReconciliation_plannedTransactionId_idx": {
+          "name": "transactionReconciliation_plannedTransactionId_idx",
+          "columns": [
+            "planned_transaction_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_reconciliation_bank_transaction_id_bank_transaction_id_fk": {
+          "name": "transaction_reconciliation_bank_transaction_id_bank_transaction_id_fk",
+          "tableFrom": "transaction_reconciliation",
+          "tableTo": "bank_transaction",
+          "columnsFrom": [
+            "bank_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_reconciliation_planned_transaction_id_planned_transaction_id_fk": {
+          "name": "transaction_reconciliation_planned_transaction_id_planned_transaction_id_fk",
+          "tableFrom": "transaction_reconciliation",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "planned_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_reconciliation_matched_by_user_id_user_id_fk": {
+          "name": "transaction_reconciliation_matched_by_user_id_user_id_fk",
+          "tableFrom": "transaction_reconciliation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "matched_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_setting": {
+      "name": "user_setting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userSetting_userId_key_idx": {
+          "name": "userSetting_userId_key_idx",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_setting_user_id_user_id_fk": {
+          "name": "user_setting_user_id_user_id_fk",
+          "tableFrom": "user_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2245 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ac82e3cf-b305-483b-bf82-9c106c48f9b8",
+  "prevId": "4065db33-10f8-45cc-9955-cd892fab17d1",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "twoFactor_userId_idx": {
+          "name": "twoFactor_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bank_transaction": {
+      "name": "bank_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_import_id": {
+          "name": "first_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_import_id": {
+          "name": "last_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_transaction_id": {
+          "name": "external_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_date": {
+          "name": "booking_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'EUR'"
+        },
+        "original_amount_cents": {
+          "name": "original_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_currency": {
+          "name": "original_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "counterparty": {
+          "name": "counterparty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_text": {
+          "name": "booking_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "balance_after_cents": {
+          "name": "balance_after_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "balance_currency": {
+          "name": "balance_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cardholder": {
+          "name": "cardholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_data_json": {
+          "name": "raw_data_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_assignment": {
+          "name": "plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "import_seen_count": {
+          "name": "import_seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bankTransaction_sourceId_dedupeKey_idx": {
+          "name": "bankTransaction_sourceId_dedupeKey_idx",
+          "columns": [
+            "source_id",
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "bankTransaction_bookingDate_idx": {
+          "name": "bankTransaction_bookingDate_idx",
+          "columns": [
+            "booking_date"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_planId_idx": {
+          "name": "bankTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_status_idx": {
+          "name": "bankTransaction_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_externalTransactionId_idx": {
+          "name": "bankTransaction_externalTransactionId_idx",
+          "columns": [
+            "external_transaction_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_isArchived_idx": {
+          "name": "bankTransaction_isArchived_idx",
+          "columns": [
+            "is_archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bank_transaction_source_id_import_source_id_fk": {
+          "name": "bank_transaction_source_id_import_source_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_first_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_first_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "first_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_last_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_last_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "last_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_plan_id_plan_id_fk": {
+          "name": "bank_transaction_plan_id_plan_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category": {
+      "name": "category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "category_name_idx": {
+          "name": "category_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "category_slug_idx": {
+          "name": "category_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_source": {
+      "name": "import_source",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_label": {
+          "name": "account_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_identifier": {
+          "name": "account_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_plan_assignment": {
+          "name": "default_plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto_month'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "importSource_preset_idx": {
+          "name": "importSource_preset_idx",
+          "columns": [
+            "preset"
+          ],
+          "isUnique": false
+        },
+        "importSource_isActive_idx": {
+          "name": "importSource_isActive_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kassensturz_dismissal": {
+      "name": "kassensturz_dismissal",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_transaction_id": {
+          "name": "bank_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dismissed_by_user_id": {
+          "name": "dismissed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kassensturzDismissal_bankTx_plan_idx": {
+          "name": "kassensturzDismissal_bankTx_plan_idx",
+          "columns": [
+            "bank_transaction_id",
+            "plan_id"
+          ],
+          "isUnique": true
+        },
+        "kassensturzDismissal_planId_idx": {
+          "name": "kassensturzDismissal_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "kassensturz_dismissal_bank_transaction_id_bank_transaction_id_fk": {
+          "name": "kassensturz_dismissal_bank_transaction_id_bank_transaction_id_fk",
+          "tableFrom": "kassensturz_dismissal",
+          "tableTo": "bank_transaction",
+          "columnsFrom": [
+            "bank_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_dismissal_plan_id_plan_id_fk": {
+          "name": "kassensturz_dismissal_plan_id_plan_id_fk",
+          "tableFrom": "kassensturz_dismissal",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_dismissal_dismissed_by_user_id_user_id_fk": {
+          "name": "kassensturz_dismissal_dismissed_by_user_id_user_id_fk",
+          "tableFrom": "kassensturz_dismissal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "dismissed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kassensturz_manual_entry": {
+      "name": "kassensturz_manual_entry",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "planned_transaction_id": {
+          "name": "planned_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kassensturzManualEntry_planId_idx": {
+          "name": "kassensturzManualEntry_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "kassensturzManualEntry_plannedTransactionId_idx": {
+          "name": "kassensturzManualEntry_plannedTransactionId_idx",
+          "columns": [
+            "planned_transaction_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "kassensturz_manual_entry_plan_id_plan_id_fk": {
+          "name": "kassensturz_manual_entry_plan_id_plan_id_fk",
+          "tableFrom": "kassensturz_manual_entry",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_manual_entry_planned_transaction_id_planned_transaction_id_fk": {
+          "name": "kassensturz_manual_entry_planned_transaction_id_planned_transaction_id_fk",
+          "tableFrom": "kassensturz_manual_entry",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "planned_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kassensturz_manual_entry_created_by_user_id_user_id_fk": {
+          "name": "kassensturz_manual_entry_created_by_user_id_user_id_fk",
+          "tableFrom": "kassensturz_manual_entry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kassensturz_match_rule": {
+      "name": "kassensturz_match_rule",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "merchant_fingerprint": {
+          "name": "merchant_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_planned_name_normalized": {
+          "name": "target_planned_name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_category_id": {
+          "name": "target_category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_amount_cents": {
+          "name": "avg_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_tolerance_cents": {
+          "name": "amount_tolerance_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confirm_count": {
+          "name": "confirm_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active": {
+          "name": "active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kassensturzMatchRule_source_fingerprint_target_idx": {
+          "name": "kassensturzMatchRule_source_fingerprint_target_idx",
+          "columns": [
+            "source_id",
+            "direction",
+            "merchant_fingerprint",
+            "target_planned_name_normalized"
+          ],
+          "isUnique": true
+        },
+        "kassensturzMatchRule_lookup_idx": {
+          "name": "kassensturzMatchRule_lookup_idx",
+          "columns": [
+            "source_id",
+            "direction",
+            "merchant_fingerprint",
+            "active"
+          ],
+          "isUnique": false
+        },
+        "kassensturzMatchRule_targetName_idx": {
+          "name": "kassensturzMatchRule_targetName_idx",
+          "columns": [
+            "target_planned_name_normalized"
+          ],
+          "isUnique": false
+        },
+        "kassensturzMatchRule_category_idx": {
+          "name": "kassensturzMatchRule_category_idx",
+          "columns": [
+            "target_category_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "kassensturz_match_rule_source_id_import_source_id_fk": {
+          "name": "kassensturz_match_rule_source_id_import_source_id_fk",
+          "tableFrom": "kassensturz_match_rule",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kassensturz_match_rule_target_category_id_category_id_fk": {
+          "name": "kassensturz_match_rule_target_category_id_category_id_fk",
+          "tableFrom": "kassensturz_match_rule",
+          "tableTo": "category",
+          "columnsFrom": [
+            "target_category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan": {
+      "name": "plan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plan_date_idx": {
+          "name": "plan_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "planned_transaction": {
+      "name": "planned_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_done": {
+          "name": "is_done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plannedTransaction_planId_idx": {
+          "name": "plannedTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_userId_idx": {
+          "name": "plannedTransaction_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_dueDate_idx": {
+          "name": "plannedTransaction_dueDate_idx",
+          "columns": [
+            "due_date"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_categoryId_idx": {
+          "name": "plannedTransaction_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_type_idx": {
+          "name": "plannedTransaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "planned_transaction_plan_id_plan_id_fk": {
+          "name": "planned_transaction_plan_id_plan_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_user_id_user_id_fk": {
+          "name": "planned_transaction_user_id_user_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_category_id_category_id_fk": {
+          "name": "planned_transaction_category_id_category_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "statement_import": {
+      "name": "statement_import",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_sha256": {
+          "name": "file_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preview_count": {
+          "name": "preview_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "statementImport_sourceId_idx": {
+          "name": "statementImport_sourceId_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "statementImport_fileSha256_idx": {
+          "name": "statementImport_fileSha256_idx",
+          "columns": [
+            "file_sha256"
+          ],
+          "isUnique": false
+        },
+        "statementImport_createdAt_idx": {
+          "name": "statementImport_createdAt_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "statement_import_source_id_import_source_id_fk": {
+          "name": "statement_import_source_id_import_source_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_import_triggered_by_user_id_user_id_fk": {
+          "name": "statement_import_triggered_by_user_id_user_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_preset": {
+      "name": "transaction_preset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'einmalig'"
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionPreset_userId_idx": {
+          "name": "transactionPreset_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_categoryId_idx": {
+          "name": "transactionPreset_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_type_idx": {
+          "name": "transactionPreset_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_recurrence_idx": {
+          "name": "transactionPreset_recurrence_idx",
+          "columns": [
+            "recurrence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_preset_user_id_user_id_fk": {
+          "name": "transaction_preset_user_id_user_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_preset_category_id_category_id_fk": {
+          "name": "transaction_preset_category_id_category_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_reconciliation": {
+      "name": "transaction_reconciliation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_transaction_id": {
+          "name": "bank_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "planned_transaction_id": {
+          "name": "planned_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "matched_at": {
+          "name": "matched_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "matched_by_user_id": {
+          "name": "matched_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionReconciliation_bankTransactionId_idx": {
+          "name": "transactionReconciliation_bankTransactionId_idx",
+          "columns": [
+            "bank_transaction_id"
+          ],
+          "isUnique": true
+        },
+        "transactionReconciliation_plannedTransactionId_idx": {
+          "name": "transactionReconciliation_plannedTransactionId_idx",
+          "columns": [
+            "planned_transaction_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_reconciliation_bank_transaction_id_bank_transaction_id_fk": {
+          "name": "transaction_reconciliation_bank_transaction_id_bank_transaction_id_fk",
+          "tableFrom": "transaction_reconciliation",
+          "tableTo": "bank_transaction",
+          "columnsFrom": [
+            "bank_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_reconciliation_planned_transaction_id_planned_transaction_id_fk": {
+          "name": "transaction_reconciliation_planned_transaction_id_planned_transaction_id_fk",
+          "tableFrom": "transaction_reconciliation",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "planned_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_reconciliation_matched_by_user_id_user_id_fk": {
+          "name": "transaction_reconciliation_matched_by_user_id_user_id_fk",
+          "tableFrom": "transaction_reconciliation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "matched_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_setting": {
+      "name": "user_setting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userSetting_userId_key_idx": {
+          "name": "userSetting_userId_key_idx",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_setting_user_id_user_id_fk": {
+          "name": "user_setting_user_id_user_id_fk",
+          "tableFrom": "user_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1771715495666,
       "tag": "0009_left_falcon",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1772132515668,
+      "tag": "0010_early_doctor_faustus",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772132515668,
       "tag": "0010_early_doctor_faustus",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1772137324467,
+      "tag": "0011_yielding_manta",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/bank-transactions/BankTransactionManager.vue
+++ b/src/components/bank-transactions/BankTransactionManager.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import type {
   BankTransactionWithRelations,
   ImportSource,
@@ -35,7 +35,16 @@ import {
   PaginationPrevious,
 } from '@/components/ui/pagination'
 import { Button } from '@/components/ui/button'
-import { Landmark, Search, Upload, X } from 'lucide-vue-next'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import {
+  Archive,
+  ArchiveRestore,
+  Landmark,
+  Search,
+  Upload,
+  X,
+} from 'lucide-vue-next'
 import BankTransactionTable from './BankTransactionTable.vue'
 import BankImportDialog from './BankImportDialog.vue'
 
@@ -63,6 +72,7 @@ const {
   loadSources,
   updateTransactionPlan,
   updateTransactionNote,
+  bulkArchiveTransactions,
 } = useBankTransactions(filters, {
   transactions: props.initialTransactions,
   pagination: props.initialPagination,
@@ -71,6 +81,77 @@ const {
 })
 
 const importDialogOpen = ref(false)
+const selectedIds = ref<Set<string>>(new Set())
+const lastSelectedId = ref<string | null>(null)
+
+// Clear selection on filter/page changes
+watch(
+  () => ({ ...filters.state }),
+  () => {
+    selectedIds.value = new Set()
+    lastSelectedId.value = null
+  },
+  { deep: true },
+)
+
+function toggleSelect(id: string, shiftKey: boolean) {
+  const next = new Set(selectedIds.value)
+  if (shiftKey && lastSelectedId.value) {
+    const txList = transactions.value
+    const anchorIdx = txList.findIndex((tx) => tx.id === lastSelectedId.value)
+    const currentIdx = txList.findIndex((tx) => tx.id === id)
+    if (anchorIdx !== -1 && currentIdx !== -1) {
+      const [start, end] = [
+        Math.min(anchorIdx, currentIdx),
+        Math.max(anchorIdx, currentIdx),
+      ]
+      for (let i = start; i <= end; i++) {
+        next.add(txList[i].id)
+      }
+    }
+  } else {
+    if (next.has(id)) {
+      next.delete(id)
+    } else {
+      next.add(id)
+    }
+  }
+  selectedIds.value = next
+  lastSelectedId.value = id
+}
+
+function toggleSelectAll() {
+  const allSelected = transactions.value.every((tx) =>
+    selectedIds.value.has(tx.id),
+  )
+  if (allSelected) {
+    selectedIds.value = new Set()
+  } else {
+    selectedIds.value = new Set(transactions.value.map((tx) => tx.id))
+  }
+}
+
+function clearSelection() {
+  selectedIds.value = new Set()
+  lastSelectedId.value = null
+}
+
+async function handleBulkArchive(isArchived: boolean) {
+  const ids = Array.from(selectedIds.value)
+  if (ids.length === 0) return
+
+  const success = await bulkArchiveTransactions(ids, isArchived)
+  if (success) {
+    toast.success(
+      isArchived
+        ? `${ids.length} Transaktion(en) archiviert`
+        : `${ids.length} Transaktion(en) entarchiviert`,
+    )
+    selectedIds.value = new Set()
+  } else {
+    toast.error('Archivierung konnte nicht durchgeführt werden.')
+  }
+}
 
 function handleSort(column: 'bookingDate' | 'amountCents' | 'createdAt') {
   if (filters.sortBy.value === column) {
@@ -200,6 +281,16 @@ function handleImported() {
           class="w-[150px]"
           placeholder="Bis"
         />
+        <div class="flex items-center gap-2">
+          <Switch
+            id="show-archived"
+            :model-value="filters.showArchived.value"
+            @update:model-value="filters.showArchived.value = $event"
+          />
+          <Label for="show-archived" class="text-sm whitespace-nowrap"
+            >Archivierte zeigen</Label
+          >
+        </div>
         <Button
           variant="outline"
           size="icon"
@@ -220,10 +311,39 @@ function handleImported() {
         :sort-by="filters.sortBy.value"
         :sort-dir="filters.sortDir.value"
         :has-active-filters="filters.hasActiveFilters.value"
+        :selected-ids="selectedIds"
         @sort="handleSort"
         @update:plan="handlePlanUpdate"
         @update:note="handleNoteUpdate"
+        @toggle-select="toggleSelect"
+        @toggle-select-all="toggleSelectAll"
       />
+
+      <!-- Floating action bar -->
+      <div
+        v-if="selectedIds.size > 0"
+        class="bg-background/80 sticky bottom-0 z-10 mt-4 flex items-center gap-3 rounded-md border px-4 py-3 shadow-md backdrop-blur-sm"
+      >
+        <span class="text-sm font-medium">
+          {{ selectedIds.size }} ausgewählt
+        </span>
+        <Button size="sm" @click="handleBulkArchive(true)">
+          <Archive class="mr-2 size-4" />
+          Archivieren
+        </Button>
+        <Button
+          v-if="filters.showArchived.value"
+          size="sm"
+          variant="outline"
+          @click="handleBulkArchive(false)"
+        >
+          <ArchiveRestore class="mr-2 size-4" />
+          Entarchivieren
+        </Button>
+        <Button size="sm" variant="ghost" @click="clearSelection">
+          <X class="size-4" />
+        </Button>
+      </div>
 
       <!-- Pagination -->
       <div v-if="pagination.totalPages > 1" class="mt-4">

--- a/src/components/bank-transactions/BankTransactionManager.vue
+++ b/src/components/bank-transactions/BankTransactionManager.vue
@@ -219,8 +219,8 @@ function handleImported() {
       </div>
 
       <!-- Filters -->
-      <div class="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center">
-        <div class="relative flex-1">
+      <div class="mb-4 space-y-3">
+        <div class="relative w-full">
           <Search
             class="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2"
           />
@@ -232,74 +232,77 @@ function handleImported() {
             @keyup.escape="filters.search.value = ''"
           />
         </div>
-        <Select v-model="filters.sourceId.value">
-          <SelectTrigger class="w-[180px]">
-            <SelectValue placeholder="Quelle" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Alle Quellen</SelectItem>
-            <SelectItem
-              v-for="source in sources.filter((s) => s.isActive)"
-              :key="source.id"
-              :value="source.id"
-            >
-              {{ source.name }}
-            </SelectItem>
-          </SelectContent>
-        </Select>
-        <Select v-model="filters.status.value">
-          <SelectTrigger class="w-[140px]">
-            <SelectValue placeholder="Status" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Alle Status</SelectItem>
-            <SelectItem value="booked">Gebucht</SelectItem>
-            <SelectItem value="pending">Ausstehend</SelectItem>
-            <SelectItem value="unknown">Unbekannt</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select v-model="filters.planId.value">
-          <SelectTrigger class="w-[180px]">
-            <SelectValue placeholder="Plan" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Alle Pläne</SelectItem>
-            <SelectItem v-for="p in plans" :key="p.id" :value="p.id">
-              {{ getPlanDisplayName(p.name, p.date) }}
-            </SelectItem>
-          </SelectContent>
-        </Select>
-        <Input
-          v-model="filters.dateFrom.value"
-          type="date"
-          class="w-[150px]"
-          placeholder="Von"
-        />
-        <Input
-          v-model="filters.dateTo.value"
-          type="date"
-          class="w-[150px]"
-          placeholder="Bis"
-        />
-        <div class="flex items-center gap-2">
-          <Switch
-            id="show-archived"
-            :model-value="filters.showArchived.value"
-            @update:model-value="filters.showArchived.value = $event"
+        <div class="flex flex-wrap items-center gap-2">
+          <Select v-model="filters.sourceId.value">
+            <SelectTrigger class="w-[150px]">
+              <SelectValue placeholder="Quelle" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Alle Quellen</SelectItem>
+              <SelectItem
+                v-for="source in sources.filter((s) => s.isActive)"
+                :key="source.id"
+                :value="source.id"
+              >
+                {{ source.name }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <Select v-model="filters.status.value">
+            <SelectTrigger class="w-[140px]">
+              <SelectValue placeholder="Status" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Alle Status</SelectItem>
+              <SelectItem value="booked">Gebucht</SelectItem>
+              <SelectItem value="pending">Ausstehend</SelectItem>
+              <SelectItem value="unknown">Unbekannt</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select v-model="filters.planId.value">
+            <SelectTrigger class="w-[150px]">
+              <SelectValue placeholder="Plan" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Alle Pläne</SelectItem>
+              <SelectItem v-for="p in plans" :key="p.id" :value="p.id">
+                {{ getPlanDisplayName(p.name, p.date) }}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <Input
+            v-model="filters.dateFrom.value"
+            type="date"
+            class="w-[130px]"
+            placeholder="Von"
           />
-          <Label for="show-archived" class="text-sm whitespace-nowrap"
-            >Archivierte zeigen</Label
+          <Input
+            v-model="filters.dateTo.value"
+            type="date"
+            class="w-[130px]"
+            placeholder="Bis"
+          />
+          <div class="flex items-center gap-2">
+            <Switch
+              id="show-archived"
+              :model-value="filters.showArchived.value"
+              @update:model-value="filters.showArchived.value = $event"
+            />
+            <Label for="show-archived" class="text-sm whitespace-nowrap"
+              >Archivierte zeigen</Label
+            >
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            title="Filter zurücksetzen"
+            class="ml-auto"
+            :disabled="!filters.hasActiveFilters.value"
+            @click="filters.resetFilters"
           >
+            <X class="size-4" />
+          </Button>
         </div>
-        <Button
-          variant="outline"
-          size="icon"
-          title="Filter zurücksetzen"
-          :disabled="!filters.hasActiveFilters.value"
-          @click="filters.resetFilters"
-        >
-          <X class="size-4" />
-        </Button>
       </div>
 
       <!-- Table -->

--- a/src/components/bank-transactions/BankTransactionManager.vue
+++ b/src/components/bank-transactions/BankTransactionManager.vue
@@ -62,6 +62,7 @@ const {
   loadTransactions,
   loadSources,
   updateTransactionPlan,
+  updateTransactionNote,
 } = useBankTransactions(filters, {
   transactions: props.initialTransactions,
   pagination: props.initialPagination,
@@ -90,6 +91,15 @@ async function handlePlanUpdate(transactionId: string, planId: string | null) {
     toast.success(planId ? 'Plan zugewiesen' : 'Plan entfernt')
   } else {
     toast.error('Plan konnte nicht aktualisiert werden.')
+  }
+}
+
+async function handleNoteUpdate(transactionId: string, note: string | null) {
+  const success = await updateTransactionNote(transactionId, note)
+  if (success) {
+    toast.success(note ? 'Notiz gespeichert' : 'Notiz entfernt')
+  } else {
+    toast.error('Notiz konnte nicht gespeichert werden.')
   }
 }
 
@@ -212,6 +222,7 @@ function handleImported() {
         :has-active-filters="filters.hasActiveFilters.value"
         @sort="handleSort"
         @update:plan="handlePlanUpdate"
+        @update:note="handleNoteUpdate"
       />
 
       <!-- Pagination -->

--- a/src/components/bank-transactions/BankTransactionTable.vue
+++ b/src/components/bank-transactions/BankTransactionTable.vue
@@ -2,6 +2,7 @@
 import type { BankTransactionWithRelations } from '@/lib/bank-transactions'
 import type { Plan } from '@/lib/plans'
 import { formatAmount, formatDate } from '@/lib/format'
+import NoteEditor from './NoteEditor.vue'
 import PlanPicker from './PlanPicker.vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -13,6 +14,12 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import {
   ArrowDown,
   ArrowUp,
@@ -35,6 +42,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   sort: [column: 'bookingDate' | 'amountCents' | 'createdAt']
   'update:plan': [transactionId: string, planId: string | null]
+  'update:note': [transactionId: string, note: string | null]
 }>()
 
 function getSortIcon(column: 'bookingDate' | 'amountCents' | 'createdAt') {
@@ -97,6 +105,7 @@ function statusVariant(
               <component :is="getSortIcon('bookingDate')" class="ml-2 size-4" />
             </Button>
           </TableHead>
+          <TableHead class="w-10"></TableHead>
           <TableHead>Beschreibung</TableHead>
           <TableHead class="w-36">
             <Button
@@ -115,22 +124,40 @@ function statusVariant(
         </TableRow>
       </TableHeader>
       <TableBody>
-        <TableRow v-for="tx in transactions" :key="tx.id">
+        <TableRow v-for="tx in transactions" :key="tx.id" class="group/row">
           <!-- Date -->
           <TableCell>{{ formatDate(tx.bookingDate) }}</TableCell>
+
+          <!-- Note -->
+          <TableCell class="px-0">
+            <NoteEditor
+              :note="tx.note"
+              :transaction-id="tx.id"
+              @update:note="(id, note) => emit('update:note', id, note)"
+            />
+          </TableCell>
 
           <!-- Description -->
           <TableCell>
             <div>
-              <span v-if="tx.counterparty" class="font-medium">{{
-                tx.counterparty
-              }}</span>
-              <p
-                v-if="tx.description"
-                class="text-muted-foreground truncate text-sm"
-              >
-                {{ tx.description }}
-              </p>
+              <TooltipProvider v-if="tx.counterparty ?? tx.description">
+                <Tooltip>
+                  <TooltipTrigger as-child>
+                    <span class="font-medium">{{
+                      tx.counterparty ?? tx.description
+                    }}</span>
+                  </TooltipTrigger>
+                  <TooltipContent v-if="tx.note">
+                    <p class="max-w-64">
+                      {{
+                        tx.note.length > 100
+                          ? tx.note.slice(0, 100) + '…'
+                          : tx.note
+                      }}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
           </TableCell>
 

--- a/src/components/bank-transactions/BankTransactionTable.vue
+++ b/src/components/bank-transactions/BankTransactionTable.vue
@@ -183,14 +183,16 @@ function statusVariant(
             <div>
               <TooltipProvider v-if="tx.counterparty ?? tx.description">
                 <Tooltip>
-                  <TooltipTrigger as-child>
-                    <span class="block max-w-[240px] truncate font-medium">{{
-                      tx.counterparty ?? tx.description
-                    }}</span>
-                    <Badge v-if="tx.isArchived" variant="outline" class="ml-2"
+                  <span class="flex items-center gap-2">
+                    <TooltipTrigger as-child>
+                      <span class="max-w-[240px] truncate font-medium">{{
+                        tx.counterparty ?? tx.description
+                      }}</span>
+                    </TooltipTrigger>
+                    <Badge v-if="tx.isArchived" variant="outline"
                       >Archiviert</Badge
                     >
-                  </TooltipTrigger>
+                  </span>
                   <TooltipContent v-if="tx.note">
                     <p class="max-w-64">
                       {{

--- a/src/components/bank-transactions/BankTransactionTable.vue
+++ b/src/components/bank-transactions/BankTransactionTable.vue
@@ -146,9 +146,9 @@ function statusVariant(
               <component :is="getSortIcon('amountCents')" class="ml-2 size-4" />
             </Button>
           </TableHead>
-          <TableHead>Quelle</TableHead>
+          <TableHead class="hidden lg:table-cell">Quelle</TableHead>
           <TableHead class="w-28">Status</TableHead>
-          <TableHead>Plan</TableHead>
+          <TableHead class="hidden xl:table-cell">Plan</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -184,7 +184,7 @@ function statusVariant(
               <TooltipProvider v-if="tx.counterparty ?? tx.description">
                 <Tooltip>
                   <TooltipTrigger as-child>
-                    <span class="font-medium">{{
+                    <span class="block max-w-[240px] truncate font-medium">{{
                       tx.counterparty ?? tx.description
                     }}</span>
                     <Badge v-if="tx.isArchived" variant="outline" class="ml-2"
@@ -219,7 +219,7 @@ function statusVariant(
           </TableCell>
 
           <!-- Source -->
-          <TableCell>
+          <TableCell class="hidden lg:table-cell">
             <span class="text-muted-foreground text-sm">{{
               tx.sourceName || '-'
             }}</span>
@@ -233,7 +233,7 @@ function statusVariant(
           </TableCell>
 
           <!-- Plan -->
-          <TableCell>
+          <TableCell class="hidden xl:table-cell">
             <PlanPicker
               :plans="plans"
               :plan-id="tx.planId"

--- a/src/components/bank-transactions/BankTransactionTable.vue
+++ b/src/components/bank-transactions/BankTransactionTable.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { BankTransactionWithRelations } from '@/lib/bank-transactions'
 import type { Plan } from '@/lib/plans'
 import { formatAmount, formatDate } from '@/lib/format'
@@ -6,6 +7,7 @@ import NoteEditor from './NoteEditor.vue'
 import PlanPicker from './PlanPicker.vue'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Table,
   TableBody,
@@ -37,13 +39,27 @@ const props = defineProps<{
   sortBy: 'bookingDate' | 'amountCents' | 'createdAt'
   sortDir: 'asc' | 'desc'
   hasActiveFilters: boolean
+  selectedIds: Set<string>
 }>()
 
 const emit = defineEmits<{
   sort: [column: 'bookingDate' | 'amountCents' | 'createdAt']
   'update:plan': [transactionId: string, planId: string | null]
   'update:note': [transactionId: string, note: string | null]
+  'toggle-select': [id: string, shiftKey: boolean]
+  'toggle-select-all': []
 }>()
+
+const allOnPageSelected = computed(
+  () =>
+    props.transactions.length > 0 &&
+    props.transactions.every((tx) => props.selectedIds.has(tx.id)),
+)
+const someOnPageSelected = computed(
+  () =>
+    !allOnPageSelected.value &&
+    props.transactions.some((tx) => props.selectedIds.has(tx.id)),
+)
 
 function getSortIcon(column: 'bookingDate' | 'amountCents' | 'createdAt') {
   if (props.sortBy !== column) return ArrowUpDown
@@ -94,6 +110,18 @@ function statusVariant(
     <Table>
       <TableHeader>
         <TableRow>
+          <TableHead class="w-10">
+            <Checkbox
+              :model-value="
+                allOnPageSelected
+                  ? true
+                  : someOnPageSelected
+                    ? 'indeterminate'
+                    : false
+              "
+              @update:model-value="emit('toggle-select-all')"
+            />
+          </TableHead>
           <TableHead class="w-36">
             <Button
               variant="ghost"
@@ -124,7 +152,20 @@ function statusVariant(
         </TableRow>
       </TableHeader>
       <TableBody>
-        <TableRow v-for="tx in transactions" :key="tx.id" class="group/row">
+        <TableRow
+          v-for="tx in transactions"
+          :key="tx.id"
+          class="group/row"
+          :class="{ 'opacity-60': tx.isArchived }"
+        >
+          <!-- Checkbox -->
+          <TableCell
+            class="cursor-pointer"
+            @click="(e: MouseEvent) => emit('toggle-select', tx.id, e.shiftKey)"
+          >
+            <Checkbox :model-value="selectedIds.has(tx.id)" />
+          </TableCell>
+
           <!-- Date -->
           <TableCell>{{ formatDate(tx.bookingDate) }}</TableCell>
 
@@ -146,6 +187,9 @@ function statusVariant(
                     <span class="font-medium">{{
                       tx.counterparty ?? tx.description
                     }}</span>
+                    <Badge v-if="tx.isArchived" variant="outline" class="ml-2"
+                      >Archiviert</Badge
+                    >
                   </TooltipTrigger>
                   <TooltipContent v-if="tx.note">
                     <p class="max-w-64">

--- a/src/components/bank-transactions/NoteEditor.vue
+++ b/src/components/bank-transactions/NoteEditor.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { StickyNote } from 'lucide-vue-next'
+
+const props = defineProps<{
+  note: string | null
+  transactionId: string
+}>()
+
+const emit = defineEmits<{
+  'update:note': [transactionId: string, note: string | null]
+}>()
+
+const open = ref(false)
+const draft = ref(props.note ?? '')
+
+watch(
+  () => props.note,
+  (val) => {
+    if (!open.value) {
+      draft.value = val ?? ''
+    }
+  },
+)
+
+watch(open, (isOpen) => {
+  if (isOpen) {
+    draft.value = props.note ?? ''
+  } else {
+    const trimmed = draft.value.trim()
+    const newNote = trimmed.length > 0 ? trimmed : null
+    if (newNote !== props.note) {
+      emit('update:note', props.transactionId, newNote)
+    }
+  }
+})
+</script>
+
+<template>
+  <Popover v-model:open="open">
+    <PopoverTrigger as-child>
+      <Button
+        variant="ghost"
+        size="icon"
+        class="size-8"
+        :class="
+          note
+            ? 'text-amber-600 dark:text-amber-400'
+            : 'text-muted-foreground opacity-0 group-hover/row:opacity-100'
+        "
+      >
+        <StickyNote class="size-4" />
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent class="w-72" align="start">
+      <Textarea
+        v-model="draft"
+        placeholder="Notiz eingeben..."
+        class="min-h-[80px] resize-none"
+        :maxlength="2000"
+        @keydown.meta.enter="open = false"
+        @keydown.ctrl.enter="open = false"
+      />
+    </PopoverContent>
+  </Popover>
+</template>

--- a/src/composables/useBankTransactionFilters.ts
+++ b/src/composables/useBankTransactionFilters.ts
@@ -9,6 +9,7 @@ export function useBankTransactionFilters() {
     planId: { type: 'string', default: 'all', urlKey: 'plan' },
     dateFrom: { type: 'string', default: '', urlKey: 'from' },
     dateTo: { type: 'string', default: '', urlKey: 'to' },
+    showArchived: { type: 'boolean', default: false, urlKey: 'archived' },
     sortBy: {
       type: 'enum',
       default: 'bookingDate' as const,
@@ -94,6 +95,14 @@ export function useBankTransactionFilters() {
       state.page = v
     },
   })
+  const showArchived = computed({
+    get: () => state.showArchived,
+    set: (v: boolean) => {
+      if (state.showArchived === v) return
+      state.showArchived = v
+      state.page = 1
+    },
+  })
 
   return {
     search,
@@ -102,6 +111,7 @@ export function useBankTransactionFilters() {
     planId,
     dateFrom,
     dateTo,
+    showArchived,
     sortBy,
     sortDir,
     page,

--- a/src/composables/useBankTransactions.ts
+++ b/src/composables/useBankTransactions.ts
@@ -48,6 +48,7 @@ export function useBankTransactions(
       }
       if (filters.dateFrom.value) params.set('dateFrom', filters.dateFrom.value)
       if (filters.dateTo.value) params.set('dateTo', filters.dateTo.value)
+      if (filters.showArchived.value) params.set('showArchived', 'true')
       params.set('sortBy', filters.sortBy.value)
       params.set('sortDir', filters.sortDir.value)
       params.set('page', filters.page.value.toString())
@@ -162,6 +163,33 @@ export function useBankTransactions(
     }
   }
 
+  async function bulkArchiveTransactions(
+    ids: string[],
+    isArchived: boolean,
+  ): Promise<boolean> {
+    try {
+      const response = await fetch('/api/bank-transactions/bulk-archive', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids, isArchived }),
+      })
+      if (!response.ok) throw new Error('Bulk archive failed')
+      await loadTransactions()
+      // If current page is now empty but there are still results, jump to last valid page
+      if (
+        transactions.value.length === 0 &&
+        pagination.value.total > 0 &&
+        filters.page.value > 1
+      ) {
+        filters.page.value = Math.max(1, pagination.value.totalPages)
+      }
+      return true
+    } catch {
+      errorMessage.value = 'Archivierung konnte nicht durchgeführt werden.'
+      return false
+    }
+  }
+
   // Watch filters for changes and auto-fetch
   watch(
     () => ({ ...filters.state }),
@@ -181,5 +209,6 @@ export function useBankTransactions(
     loadPlans,
     updateTransactionPlan,
     updateTransactionNote,
+    bulkArchiveTransactions,
   }
 }

--- a/src/composables/useBankTransactions.ts
+++ b/src/composables/useBankTransactions.ts
@@ -135,6 +135,33 @@ export function useBankTransactions(
     }
   }
 
+  async function updateTransactionNote(
+    id: string,
+    note: string | null,
+  ): Promise<boolean> {
+    const tx = transactions.value.find((t) => t.id === id)
+    if (!tx) return false
+
+    const originalNote = tx.note
+
+    // Optimistic update
+    tx.note = note
+
+    try {
+      const response = await fetch(`/api/bank-transactions/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note }),
+      })
+      if (!response.ok) throw new Error('Update failed')
+      return true
+    } catch {
+      // Rollback
+      tx.note = originalNote
+      return false
+    }
+  }
+
   // Watch filters for changes and auto-fetch
   watch(
     () => ({ ...filters.state }),
@@ -153,5 +180,6 @@ export function useBankTransactions(
     loadSources,
     loadPlans,
     updateTransactionPlan,
+    updateTransactionNote,
   }
 }

--- a/src/db/schema/plans.ts
+++ b/src/db/schema/plans.ts
@@ -229,6 +229,9 @@ export const bankTransaction = sqliteTable(
     })
       .notNull()
       .default('none'),
+    isArchived: integer('is_archived', { mode: 'boolean' })
+      .default(false)
+      .notNull(),
     importSeenCount: integer('import_seen_count').notNull().default(1),
     createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
     updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
@@ -246,6 +249,7 @@ export const bankTransaction = sqliteTable(
     index('bankTransaction_externalTransactionId_idx').on(
       table.externalTransactionId,
     ),
+    index('bankTransaction_isArchived_idx').on(table.isArchived),
   ],
 )
 

--- a/src/db/schema/plans.ts
+++ b/src/db/schema/plans.ts
@@ -221,6 +221,7 @@ export const bankTransaction = sqliteTable(
     country: text('country'),
     cardLast4: text('card_last4'),
     cardholder: text('cardholder'),
+    note: text('note'),
     rawDataJson: text('raw_data_json').notNull(),
     planId: text('plan_id').references(() => plan.id, { onDelete: 'set null' }),
     planAssignment: text('plan_assignment', {

--- a/src/lib/bank-transactions.ts
+++ b/src/lib/bank-transactions.ts
@@ -285,6 +285,22 @@ export async function updateBankTransactionPlan(
   return updated
 }
 
+export async function updateBankTransactionNote(
+  id: string,
+  note: string | null,
+): Promise<BankTransaction | undefined> {
+  const [updated] = await db
+    .update(bankTransaction)
+    .set({
+      note,
+      updatedAt: new Date(),
+    })
+    .where(eq(bankTransaction.id, id))
+    .returning()
+
+  return updated
+}
+
 export async function createManualReconciliation(input: {
   bankTransactionId: string
   plannedTransactionId: string

--- a/src/lib/bank-transactions.ts
+++ b/src/lib/bank-transactions.ts
@@ -14,6 +14,7 @@ import {
   eq,
   getTableColumns,
   gte,
+  inArray,
   like,
   lte,
   or,
@@ -63,6 +64,7 @@ export interface BankTransactionQueryOptions {
   search?: string
   dateFrom?: string
   dateTo?: string
+  showArchived?: boolean
   sortBy?: 'bookingDate' | 'amountCents' | 'createdAt'
   sortDir?: 'asc' | 'desc'
   page?: number
@@ -198,6 +200,9 @@ export async function getBankTransactions(
   if (status) conditions.push(eq(bankTransaction.status, status))
   if (dateFrom) conditions.push(gte(bankTransaction.bookingDate, dateFrom))
   if (dateTo) conditions.push(lte(bankTransaction.bookingDate, dateTo))
+  if (!options.showArchived) {
+    conditions.push(eq(bankTransaction.isArchived, false))
+  }
   if (search) {
     conditions.push(
       or(
@@ -442,4 +447,16 @@ export async function getPlannedTransactionById(
   return db.query.plannedTransaction.findFirst({
     where: eq(plannedTransaction.id, id),
   })
+}
+
+export async function bulkArchiveBankTransactions(
+  ids: string[],
+  isArchived: boolean,
+): Promise<number> {
+  const result = await db
+    .update(bankTransaction)
+    .set({ isArchived, updatedAt: new Date() })
+    .where(inArray(bankTransaction.id, ids))
+    .returning({ id: bankTransaction.id })
+  return result.length
 }

--- a/src/lib/bank-transactions.ts
+++ b/src/lib/bank-transactions.ts
@@ -306,6 +306,35 @@ export async function updateBankTransactionNote(
   return updated
 }
 
+export async function updateBankTransactionFields(
+  id: string,
+  fields: {
+    planId?: string | null
+    note?: string | null
+  },
+): Promise<BankTransaction | undefined> {
+  const setValues: Partial<typeof bankTransaction.$inferInsert> = {
+    updatedAt: new Date(),
+  }
+
+  if (fields.planId !== undefined) {
+    setValues.planId = fields.planId
+    setValues.planAssignment = fields.planId ? 'manual' : 'none'
+  }
+
+  if (fields.note !== undefined) {
+    setValues.note = fields.note
+  }
+
+  const [updated] = await db
+    .update(bankTransaction)
+    .set(setValues)
+    .where(eq(bankTransaction.id, id))
+    .returning()
+
+  return updated
+}
+
 export async function createManualReconciliation(input: {
   bankTransactionId: string
   plannedTransactionId: string

--- a/src/pages/api/bank-transactions/[id].ts
+++ b/src/pages/api/bank-transactions/[id].ts
@@ -2,13 +2,19 @@ import type { APIRoute } from 'astro'
 import { z } from 'zod'
 import {
   getBankTransactionById,
+  updateBankTransactionNote,
   updateBankTransactionPlan,
 } from '@/lib/bank-transactions'
 import { getPlanById } from '@/lib/plans'
 
-const patchSchema = z.object({
-  planId: z.uuid().nullable(),
-})
+const patchSchema = z
+  .object({
+    planId: z.uuid().nullable().optional(),
+    note: z.string().max(2000).nullable().optional(),
+  })
+  .refine((data) => data.planId !== undefined || data.note !== undefined, {
+    message: 'Mindestens ein Feld (planId oder note) muss angegeben werden.',
+  })
 
 export const PATCH: APIRoute = async ({ params, request }) => {
   const id = params.id
@@ -53,29 +59,37 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     )
   }
 
-  if (parsed.data.planId) {
-    const targetPlan = await getPlanById(parsed.data.planId)
-    if (!targetPlan) {
-      return new Response(
-        JSON.stringify({ error: 'Zielplan nicht gefunden' }),
-        {
-          status: 404,
-          headers: { 'Content-Type': 'application/json' },
-        },
-      )
+  let updated: Awaited<ReturnType<typeof updateBankTransactionPlan>> = existing
+
+  if (parsed.data.planId !== undefined) {
+    if (parsed.data.planId) {
+      const targetPlan = await getPlanById(parsed.data.planId)
+      if (!targetPlan) {
+        return new Response(
+          JSON.stringify({ error: 'Zielplan nicht gefunden' }),
+          {
+            status: 404,
+            headers: { 'Content-Type': 'application/json' },
+          },
+        )
+      }
+      if (targetPlan.isArchived) {
+        return new Response(
+          JSON.stringify({
+            error:
+              'Banktransaktionen können nicht einem archivierten Plan zugeordnet werden.',
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
     }
-    if (targetPlan.isArchived) {
-      return new Response(
-        JSON.stringify({
-          error:
-            'Banktransaktionen können nicht einem archivierten Plan zugeordnet werden.',
-        }),
-        { status: 400, headers: { 'Content-Type': 'application/json' } },
-      )
-    }
+    updated = await updateBankTransactionPlan(id, parsed.data.planId)
   }
 
-  const updated = await updateBankTransactionPlan(id, parsed.data.planId)
+  if (parsed.data.note !== undefined) {
+    updated = await updateBankTransactionNote(id, parsed.data.note)
+  }
+
   return new Response(JSON.stringify(updated), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },

--- a/src/pages/api/bank-transactions/[id].ts
+++ b/src/pages/api/bank-transactions/[id].ts
@@ -2,8 +2,7 @@ import type { APIRoute } from 'astro'
 import { z } from 'zod'
 import {
   getBankTransactionById,
-  updateBankTransactionNote,
-  updateBankTransactionPlan,
+  updateBankTransactionFields,
 } from '@/lib/bank-transactions'
 import { getPlanById } from '@/lib/plans'
 
@@ -59,8 +58,6 @@ export const PATCH: APIRoute = async ({ params, request }) => {
     )
   }
 
-  let updated: Awaited<ReturnType<typeof updateBankTransactionPlan>> = existing
-
   if (parsed.data.planId !== undefined) {
     if (parsed.data.planId) {
       const targetPlan = await getPlanById(parsed.data.planId)
@@ -83,12 +80,12 @@ export const PATCH: APIRoute = async ({ params, request }) => {
         )
       }
     }
-    updated = await updateBankTransactionPlan(id, parsed.data.planId)
   }
 
-  if (parsed.data.note !== undefined) {
-    updated = await updateBankTransactionNote(id, parsed.data.note)
-  }
+  const updated = await updateBankTransactionFields(id, {
+    ...(parsed.data.planId !== undefined && { planId: parsed.data.planId }),
+    ...(parsed.data.note !== undefined && { note: parsed.data.note }),
+  })
 
   return new Response(JSON.stringify(updated), {
     status: 200,

--- a/src/pages/api/bank-transactions/bulk-archive.ts
+++ b/src/pages/api/bank-transactions/bulk-archive.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from 'astro'
+import { z } from 'zod'
+import { bulkArchiveBankTransactions } from '@/lib/bank-transactions'
+
+const bulkArchiveSchema = z.object({
+  ids: z.array(z.uuid()).min(1).max(100),
+  isArchived: z.boolean(),
+})
+
+export const POST: APIRoute = async ({ request }) => {
+  let body
+  try {
+    body = await request.json()
+  } catch {
+    return new Response(JSON.stringify({ error: 'Ungültiger Request-Body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  const parsed = bulkArchiveSchema.safeParse(body)
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({ error: parsed.error.issues[0]?.message }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+
+  try {
+    const count = await bulkArchiveBankTransactions(
+      parsed.data.ids,
+      parsed.data.isArchived,
+    )
+
+    return new Response(JSON.stringify({ success: true, count }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (error) {
+    console.error('Error bulk archiving bank transactions:', error)
+    return new Response(
+      JSON.stringify({
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Fehler beim Archivieren der Transaktionen',
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    )
+  }
+}

--- a/src/pages/api/bank-transactions/index.ts
+++ b/src/pages/api/bank-transactions/index.ts
@@ -15,6 +15,7 @@ const querySchema = z.object({
     .string()
     .regex(/^\d{4}-\d{2}-\d{2}$/)
     .optional(),
+  showArchived: z.coerce.boolean().optional(),
   sortBy: z.enum(['bookingDate', 'amountCents', 'createdAt']).optional(),
   sortDir: z.enum(['asc', 'desc']).optional(),
   page: z.coerce.number().min(1).optional().default(1),
@@ -35,6 +36,7 @@ export const GET: APIRoute = async ({ url }) => {
     search: url.searchParams.get('search') || undefined,
     dateFrom: url.searchParams.get('dateFrom') || undefined,
     dateTo: url.searchParams.get('dateTo') || undefined,
+    showArchived: url.searchParams.get('showArchived') || undefined,
     sortBy: url.searchParams.get('sortBy') || undefined,
     sortDir: url.searchParams.get('sortDir') || undefined,
     page: url.searchParams.get('page') || undefined,


### PR DESCRIPTION
- Introduced a new NoteEditor component for managing transaction notes.
- Updated the BankTransactionManager to handle note updates.
- Enhanced the BankTransactionTable to display notes with tooltips.
- Added backend support for updating transaction notes in the database.
- Modified API endpoint to accept note updates alongside plan updates.