### PR TITLE
feat(presets): Halbjährliche Wiederholung für Vorlagen

### DIFF
--- a/src/components/presets/FillFromPresetsDialog.vue
+++ b/src/components/presets/FillFromPresetsDialog.vue
@@ -143,6 +143,7 @@ function getRecurrenceBadgeVariant(
       return 'default'
     case 'vierteljährlich':
       return 'secondary'
+    case 'halbjährlich':
     case 'jährlich':
       return 'outline'
     default:

--- a/src/components/presets/PresetCreateDialog.vue
+++ b/src/components/presets/PresetCreateDialog.vue
@@ -45,7 +45,7 @@ const newNote = ref('')
 const newAmount = ref(0)
 const newType = ref<'income' | 'expense'>('expense')
 const newRecurrence = ref<
-  'einmalig' | 'monatlich' | 'vierteljährlich' | 'jährlich'
+  'einmalig' | 'monatlich' | 'vierteljährlich' | 'halbjährlich' | 'jährlich'
 >('monatlich')
 const newStartMonth = ref(getCurrentMonth())
 const newEndDate = ref('')
@@ -197,6 +197,7 @@ async function handleSubmit() {
                 <SelectItem value="einmalig">Einmalig</SelectItem>
                 <SelectItem value="monatlich">Monatlich</SelectItem>
                 <SelectItem value="vierteljährlich">Vierteljährlich</SelectItem>
+                <SelectItem value="halbjährlich">Halbjährlich</SelectItem>
                 <SelectItem value="jährlich">Jährlich</SelectItem>
               </SelectContent>
             </Select>

--- a/src/components/presets/PresetEditDialog.vue
+++ b/src/components/presets/PresetEditDialog.vue
@@ -44,7 +44,7 @@ const editNote = ref('')
 const editAmount = ref(0)
 const editType = ref<'income' | 'expense'>('expense')
 const editRecurrence = ref<
-  'einmalig' | 'monatlich' | 'vierteljährlich' | 'jährlich'
+  'einmalig' | 'monatlich' | 'vierteljährlich' | 'halbjährlich' | 'jährlich'
 >('einmalig')
 const editStartMonth = ref('')
 const editEndDate = ref('')
@@ -176,6 +176,7 @@ async function handleSubmit() {
                 <SelectItem value="einmalig">Einmalig</SelectItem>
                 <SelectItem value="monatlich">Monatlich</SelectItem>
                 <SelectItem value="vierteljährlich">Vierteljährlich</SelectItem>
+                <SelectItem value="halbjährlich">Halbjährlich</SelectItem>
                 <SelectItem value="jährlich">Jährlich</SelectItem>
               </SelectContent>
             </Select>

--- a/src/components/presets/PresetManager.vue
+++ b/src/components/presets/PresetManager.vue
@@ -228,6 +228,7 @@ function showError(message: string) {
           <SelectItem value="einmalig">Einmalig</SelectItem>
           <SelectItem value="monatlich">Monatlich</SelectItem>
           <SelectItem value="vierteljährlich">Vierteljährlich</SelectItem>
+          <SelectItem value="halbjährlich">Halbjährlich</SelectItem>
           <SelectItem value="jährlich">Jährlich</SelectItem>
         </SelectContent>
       </Select>

--- a/src/db/schema/plans.ts
+++ b/src/db/schema/plans.ts
@@ -280,7 +280,13 @@ export const transactionPreset = sqliteTable(
   {
     ...transactionCoreColumns(),
     recurrence: text('recurrence', {
-      enum: ['einmalig', 'monatlich', 'vierteljährlich', 'jährlich'],
+      enum: [
+        'einmalig',
+        'monatlich',
+        'vierteljährlich',
+        'halbjährlich',
+        'jährlich',
+      ],
     })
       .notNull()
       .default('einmalig'),

--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -150,6 +150,7 @@ describe('formatRecurrence', () => {
     expect(formatRecurrence('einmalig')).toBe('Einmalig')
     expect(formatRecurrence('monatlich')).toBe('Monatlich')
     expect(formatRecurrence('vierteljährlich')).toBe('Vierteljährlich')
+    expect(formatRecurrence('halbjährlich')).toBe('Halbjährlich')
     expect(formatRecurrence('jährlich')).toBe('Jährlich')
   })
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -116,6 +116,7 @@ export function formatRecurrence(recurrence: string): string {
     einmalig: 'Einmalig',
     monatlich: 'Monatlich',
     vierteljährlich: 'Vierteljährlich',
+    halbjährlich: 'Halbjährlich',
     jährlich: 'Jährlich',
   }
   return map[recurrence] || recurrence

--- a/src/lib/preset-matching.ts
+++ b/src/lib/preset-matching.ts
@@ -2,15 +2,20 @@ import { transactionPreset } from '@/db/schema/plans'
 
 type TransactionPreset = typeof transactionPreset.$inferSelect
 
-function matchesQuarterlyRecurrence(
-  startMonth: string,
-  planMonth: string,
-): boolean {
-  const [startYear, startMonthNum] = startMonth.split('-').map(Number)
-  const [planYear, planMonthNum] = planMonth.split('-').map(Number)
-  const monthsDiff =
-    (planYear - startYear) * 12 + (planMonthNum - startMonthNum)
-  return monthsDiff >= 0 && monthsDiff % 3 === 0
+/**
+ * Build a matcher for recurrences that repeat every `intervalMonths` months
+ * from the start month (e.g. 3 for quarterly, 6 for half-yearly).
+ */
+function matchesEveryNMonths(
+  intervalMonths: number,
+): (startMonth: string, planMonth: string) => boolean {
+  return (startMonth, planMonth) => {
+    const [startYear, startMonthNum] = startMonth.split('-').map(Number)
+    const [planYear, planMonthNum] = planMonth.split('-').map(Number)
+    const monthsDiff =
+      (planYear - startYear) * 12 + (planMonthNum - startMonthNum)
+    return monthsDiff >= 0 && monthsDiff % intervalMonths === 0
+  }
 }
 
 function matchesYearlyRecurrence(
@@ -28,7 +33,8 @@ const recurrenceMatchers: Record<
 > = {
   einmalig: (start, plan) => plan === start,
   monatlich: (start, plan) => plan >= start,
-  vierteljährlich: matchesQuarterlyRecurrence,
+  vierteljährlich: matchesEveryNMonths(3),
+  halbjährlich: matchesEveryNMonths(6),
   jährlich: matchesYearlyRecurrence,
 }
 

--- a/src/lib/presets.test.ts
+++ b/src/lib/presets.test.ts
@@ -60,6 +60,19 @@ describe('presetMatchesPlanMonth', () => {
     expect(presetMatchesPlanMonth(preset, '2024-03')).toBe(false)
   })
 
+  it('halbjährlich matches every 6 months from start', () => {
+    const preset = makePreset({
+      recurrence: 'halbjährlich',
+      startMonth: '2024-01',
+    })
+    expect(presetMatchesPlanMonth(preset, '2024-01')).toBe(true)
+    expect(presetMatchesPlanMonth(preset, '2024-07')).toBe(true)
+    expect(presetMatchesPlanMonth(preset, '2025-01')).toBe(true)
+    expect(presetMatchesPlanMonth(preset, '2025-07')).toBe(true)
+    expect(presetMatchesPlanMonth(preset, '2024-04')).toBe(false)
+    expect(presetMatchesPlanMonth(preset, '2024-06')).toBe(false)
+  })
+
   it('jährlich matches same month each year', () => {
     const preset = makePreset({
       recurrence: 'jährlich',

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -44,7 +44,12 @@ export interface PresetQueryOptions {
   search?: string
   type?: 'income' | 'expense'
   categoryId?: string
-  recurrence?: 'einmalig' | 'monatlich' | 'vierteljährlich' | 'jährlich'
+  recurrence?:
+    | 'einmalig'
+    | 'monatlich'
+    | 'vierteljährlich'
+    | 'halbjährlich'
+    | 'jährlich'
   includeExpired?: boolean
   sortBy?: 'name' | 'createdAt' | 'lastUsedAt' | 'amount'
   sortDir?: 'asc' | 'desc'
@@ -58,7 +63,12 @@ export interface CreatePresetInput {
   note?: string | null
   type?: 'income' | 'expense'
   amount: number
-  recurrence?: 'einmalig' | 'monatlich' | 'vierteljährlich' | 'jährlich'
+  recurrence?:
+    | 'einmalig'
+    | 'monatlich'
+    | 'vierteljährlich'
+    | 'halbjährlich'
+    | 'jährlich'
   startMonth?: string | null // YYYY-MM format
   endDate?: string | null
   categoryId?: string | null
@@ -72,7 +82,12 @@ export interface UpdatePresetInput {
   note?: string | null
   type?: 'income' | 'expense'
   amount?: number
-  recurrence?: 'einmalig' | 'monatlich' | 'vierteljährlich' | 'jährlich'
+  recurrence?:
+    | 'einmalig'
+    | 'monatlich'
+    | 'vierteljährlich'
+    | 'halbjährlich'
+    | 'jährlich'
   startMonth?: string | null // YYYY-MM format
   endDate?: string | null
   categoryId?: string | null

--- a/src/pages/api/presets/_schema.ts
+++ b/src/pages/api/presets/_schema.ts
@@ -4,7 +4,13 @@ const presetCommon = {
   note: z.string().max(2000).nullable().optional(),
   type: z.enum(['income', 'expense']).optional(),
   recurrence: z
-    .enum(['einmalig', 'monatlich', 'vierteljährlich', 'jährlich'])
+    .enum([
+      'einmalig',
+      'monatlich',
+      'vierteljährlich',
+      'halbjährlich',
+      'jährlich',
+    ])
     .optional(),
   startMonth: z
     .string()

--- a/src/pages/api/presets/index.ts
+++ b/src/pages/api/presets/index.ts
@@ -29,7 +29,13 @@ const querySchema = z.object({
   type: z.enum(['income', 'expense']).optional(),
   categoryId: z.uuid().optional(),
   recurrence: z
-    .enum(['einmalig', 'monatlich', 'vierteljährlich', 'jährlich'])
+    .enum([
+      'einmalig',
+      'monatlich',
+      'vierteljährlich',
+      'halbjährlich',
+      'jährlich',
+    ])
     .optional(),
   includeExpired: z
     .string()


### PR DESCRIPTION
## Überblick

Fügt eine neue Wiederholungsoption **„Halbjährlich"** (alle sechs Monate) für Transaktionsvorlagen hinzu – neben den bestehenden Optionen einmalig / monatlich / vierteljährlich / jährlich.

## Änderungen

- **Schema & Typen:** `halbjährlich` zum Drizzle-`recurrence`-Enum, den drei Preset-Typ-Unions und den Zod-Request-Schemas ergänzt.
- **Keine DB-Migration nötig:** Die `text`-Spalte besitzt keinen CHECK-Constraint, das Drizzle-`enum` wirkt nur auf Typebene – die Snapshot-DDL ändert sich nicht.
- **Matching-Logik:** Den Quartals-Matcher in eine wiederverwendbare `matchesEveryNMonths()`-Factory umgebaut und `halbjährlich` als „alle 6 Monate ab Startmonat" registriert.
- **UI:** Label „Halbjährlich" in `formatRecurrence`, neue Option in den Anlegen-/Bearbeiten-/Filter-Selects sowie eine eigene Badge-Variante im „Aus Vorlagen befüllen"-Dialog.
- **Tests:** Neue Fälle für Matching (alle 6 Monate) und Formatierung.

## Verifikation

- `bun test` → 580 passed
- `vitest run` → 73 passed
- `oxlint --type-aware` → clean
- `astro check` → 0 errors
- `vue-tsc --noEmit` → exit 0
- `fallow audit` → keine neuen Findings (Gate bestanden)
- Code-Review (medium) durchgeführt: ein Finding (fehlende Badge-Variante für `halbjährlich`) gefunden und behoben.

🤖 Generated with [Claude Code](https://claude.com/claude-code)