### PR TITLE
feat(dashboard): fall back to nearest upcoming plan when none active

### DIFF
--- a/src/components/dashboard/DashboardBalanceCard.vue
+++ b/src/components/dashboard/DashboardBalanceCard.vue
@@ -9,10 +9,12 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 
 const props = defineProps<{
   planName: string | null
   planDate: string
+  isUpcoming: boolean
   income: number
   expense: number
   net: number
@@ -21,13 +23,19 @@ const props = defineProps<{
 const displayName = computed(() =>
   getPlanDisplayName(props.planName, props.planDate),
 )
+const cardTitle = computed(() =>
+  props.isUpcoming ? 'Nächster Saldo' : 'Aktueller Saldo',
+)
 </script>
 
 <template>
   <Card>
     <CardHeader class="pb-2">
-      <CardDescription>{{ displayName }}</CardDescription>
-      <CardTitle class="text-2xl">Aktueller Saldo</CardTitle>
+      <div class="flex items-center gap-2">
+        <CardDescription>{{ displayName }}</CardDescription>
+        <Badge v-if="isUpcoming" variant="secondary">Bevorstehend</Badge>
+      </div>
+      <CardTitle class="text-2xl">{{ cardTitle }}</CardTitle>
     </CardHeader>
     <CardContent class="space-y-3">
       <div class="flex items-center gap-2">

--- a/src/components/dashboard/DashboardContent.vue
+++ b/src/components/dashboard/DashboardContent.vue
@@ -31,11 +31,23 @@ defineProps<{
 
     <!-- Dashboard with data -->
     <template v-else>
+      <!-- Upcoming plan notice -->
+      <div
+        v-if="stats.currentPlan.isUpcoming"
+        class="bg-muted/50 rounded-xl p-3 text-sm"
+      >
+        <p class="text-muted-foreground">
+          Kein Plan für den aktuellen Monat vorhanden. Hier ist dein nächster
+          anstehender Plan.
+        </p>
+      </div>
+
       <!-- Three stat cards -->
       <div class="grid gap-4 md:grid-cols-3">
         <DashboardBalanceCard
           :plan-name="stats.currentPlan.name"
           :plan-date="stats.currentPlan.date"
+          :is-upcoming="stats.currentPlan.isUpcoming"
           :income="stats.currentPlan.income"
           :expense="stats.currentPlan.expense"
           :net="stats.currentPlan.net"

--- a/src/lib/dashboard.test.ts
+++ b/src/lib/dashboard.test.ts
@@ -9,12 +9,17 @@ import { setupTestDb } from '@/lib/__fixtures__/test-setup'
 const testDb = setupTestDb()
 
 const { getDashboardStats, getMonthlyChartData } = await import('./dashboard')
+const { formatYearMonth } = await import('./plans')
 
-async function insertPlanForCurrentMonth(id = 'plan-current') {
+async function insertPlanForFutureMonth(id = 'plan-future', offsetMonths = 2) {
   const today = new Date()
-  const currentMonth = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`
-  await seedPlan(testDb, { id, name: 'Current', date: `${currentMonth}-01` })
+  const d = new Date(today.getFullYear(), today.getMonth() + offsetMonths, 1)
+  await seedPlan(testDb, { id, name: 'Plan', date: `${formatYearMonth(d)}-01` })
   return id
+}
+
+function insertPlanForCurrentMonth(id = 'plan-current') {
+  return insertPlanForFutureMonth(id, 0)
 }
 
 async function insertCategory(
@@ -55,7 +60,7 @@ async function insertTransaction({
 }
 
 describe('getDashboardStats', () => {
-  it('returns empty stats when there is no current-month plan', async () => {
+  it('returns null currentPlan when there is no plan at all (current or future)', async () => {
     const stats = await getDashboardStats()
     expect(stats.currentPlan).toBeNull()
     expect(stats.pendingTransactions).toEqual({
@@ -64,6 +69,45 @@ describe('getDashboardStats', () => {
       expenseTotal: 0,
     })
     expect(stats.topCategories).toEqual([])
+  })
+
+  it('falls back to the nearest upcoming plan when there is no current-month plan', async () => {
+    const planId = await insertPlanForFutureMonth()
+    await insertCategory('cat-a', 'Miete')
+    await insertTransaction({
+      id: 't-income',
+      planId,
+      amount: 250000,
+      type: 'income',
+      dueDate: '2026-08-01',
+    })
+    await insertTransaction({
+      id: 't-rent',
+      planId,
+      amount: 90000,
+      type: 'expense',
+      dueDate: '2026-08-01',
+      categoryId: 'cat-a',
+    })
+
+    const stats = await getDashboardStats()
+    expect(stats.currentPlan?.id).toBe(planId)
+    expect(stats.currentPlan?.isUpcoming).toBe(true)
+    expect(stats.currentPlan?.income).toBe(250000)
+    expect(stats.currentPlan?.expense).toBe(90000)
+    expect(stats.currentPlan?.net).toBe(160000)
+    expect(stats.pendingTransactions.count).toBe(2)
+    expect(stats.topCategories).toHaveLength(1)
+    expect(stats.topCategories[0]?.name).toBe('Miete')
+  })
+
+  it('prefers the current-month plan over a future plan when both exist', async () => {
+    const currentId = await insertPlanForCurrentMonth()
+    await insertPlanForFutureMonth()
+
+    const stats = await getDashboardStats()
+    expect(stats.currentPlan?.id).toBe(currentId)
+    expect(stats.currentPlan?.isUpcoming).toBe(false)
   })
 
   it('aggregates balance, pending totals, and top categories for the current plan', async () => {
@@ -120,6 +164,7 @@ describe('getDashboardStats', () => {
 
     const stats = await getDashboardStats()
     expect(stats.currentPlan?.id).toBe(planId)
+    expect(stats.currentPlan?.isUpcoming).toBe(false)
     expect(stats.currentPlan?.income).toBe(200000)
     expect(stats.currentPlan?.expense).toBe(155000)
     expect(stats.currentPlan?.net).toBe(45000)

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -1,7 +1,7 @@
 import { db } from '@/db/database'
 import { plannedTransaction, category } from '@/db/schema/plans'
 import { and, asc, count, desc, eq, gte, sql, sum } from 'drizzle-orm'
-import { getCurrentMonthPlan } from '@/lib/plans'
+import { getActivePlan, type Plan } from '@/lib/plans'
 import { getPlanBalance } from '@/lib/transactions'
 
 // Dashboard stats types
@@ -9,6 +9,7 @@ export interface CurrentPlanStats {
   id: string
   name: string | null
   date: string
+  isUpcoming: boolean
   income: number
   expense: number
   net: number
@@ -150,12 +151,39 @@ async function getTopCategories(planId: string): Promise<TopCategory[]> {
 }
 
 /**
- * Get all dashboard stats for the current calendar month
+ * Build full dashboard stats for a specific plan.
+ */
+async function buildDashboardStatsForPlan(
+  targetPlan: Plan,
+  isUpcoming: boolean,
+): Promise<DashboardStats> {
+  const [balance, pending, categories] = await Promise.all([
+    getPlanBalance(targetPlan.id),
+    getPendingTransactionsStats(targetPlan.id),
+    getTopCategories(targetPlan.id),
+  ])
+
+  return {
+    currentPlan: {
+      id: targetPlan.id,
+      name: targetPlan.name,
+      date: targetPlan.date,
+      isUpcoming,
+      ...balance,
+    },
+    pendingTransactions: pending,
+    topCategories: categories,
+  }
+}
+
+/**
+ * Get all dashboard stats for the current calendar month, falling back to
+ * the nearest upcoming plan when no plan exists for the current month.
  */
 export async function getDashboardStats(): Promise<DashboardStats> {
-  const currentPlan = await getCurrentMonthPlan()
+  const active = await getActivePlan()
 
-  if (!currentPlan) {
+  if (!active) {
     return {
       currentPlan: null,
       pendingTransactions: {
@@ -167,22 +195,7 @@ export async function getDashboardStats(): Promise<DashboardStats> {
     }
   }
 
-  const [balance, pending, categories] = await Promise.all([
-    getPlanBalance(currentPlan.id),
-    getPendingTransactionsStats(currentPlan.id),
-    getTopCategories(currentPlan.id),
-  ])
-
-  return {
-    currentPlan: {
-      id: currentPlan.id,
-      name: currentPlan.name,
-      date: currentPlan.date,
-      ...balance,
-    },
-    pendingTransactions: pending,
-    topCategories: categories,
-  }
+  return buildDashboardStatsForPlan(active.plan, active.isUpcoming)
 }
 
 function chartStartDate(range: ChartRange, now: Date): string {

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -7,9 +7,12 @@ const testDb = setupTestDb()
 const {
   createPlan,
   deletePlan,
+  formatYearMonth,
+  getActivePlan,
   getAllPlans,
   getAvailableYears,
   getCurrentMonthPlan,
+  getNextUpcomingPlan,
   getPlanById,
   getSidebarPlans,
   searchPlans,
@@ -34,10 +37,12 @@ async function insertPlan(
   })
 }
 
-/** Current month as `YYYY-MM` — for plans that must match the live "now". */
-function currentMonthPrefix(): string {
+/** Month as `YYYY-MM`, offset from the live "now" by a number of months. */
+function monthPrefix(offsetMonths = 0): string {
   const today = new Date()
-  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`
+  return formatYearMonth(
+    new Date(today.getFullYear(), today.getMonth() + offsetMonths, 1),
+  )
 }
 
 describe('createPlan', () => {
@@ -194,7 +199,7 @@ describe('getAvailableYears', () => {
 
 describe('getCurrentMonthPlan', () => {
   it('finds an active plan whose date starts with the current YYYY-MM', async () => {
-    await insertPlan('current', `${currentMonthPrefix()}-15`)
+    await insertPlan('current', `${monthPrefix()}-15`)
     await insertPlan('other', '1999-01-01')
     const plan = await getCurrentMonthPlan()
     expect(plan?.id).toBe('current')
@@ -207,20 +212,76 @@ describe('getCurrentMonthPlan', () => {
   })
 
   it('skips archived plans even if they match the current month', async () => {
-    await insertPlan('archived', `${currentMonthPrefix()}-15`, {
+    await insertPlan('archived', `${monthPrefix()}-15`, {
       isArchived: true,
     })
     expect(await getCurrentMonthPlan()).toBeUndefined()
   })
 })
 
+describe('getNextUpcomingPlan', () => {
+  it('returns the nearest plan among multiple future-month plans', async () => {
+    await insertPlan('later', `${monthPrefix(2)}-15`)
+    await insertPlan('nearest', `${monthPrefix(1)}-01`)
+    const plan = await getNextUpcomingPlan()
+    expect(plan?.id).toBe('nearest')
+  })
+
+  it('excludes the current month, even a plan dated late in it', async () => {
+    await insertPlan('current-late', `${monthPrefix()}-28`)
+    expect(await getNextUpcomingPlan()).toBeUndefined()
+
+    await insertPlan('future', `${monthPrefix(1)}-01`)
+    const plan = await getNextUpcomingPlan()
+    expect(plan?.id).toBe('future')
+  })
+
+  it('excludes past plans', async () => {
+    await insertPlan('past', '1999-01-01')
+    await insertPlan('future', `${monthPrefix(1)}-01`)
+    const plan = await getNextUpcomingPlan()
+    expect(plan?.id).toBe('future')
+  })
+
+  it('skips archived future plans', async () => {
+    await insertPlan('archived-future', `${monthPrefix(1)}-15`, {
+      isArchived: true,
+    })
+    expect(await getNextUpcomingPlan()).toBeUndefined()
+  })
+
+  it('returns undefined when no plans exist', async () => {
+    expect(await getNextUpcomingPlan()).toBeUndefined()
+  })
+})
+
 describe('getSidebarPlans', () => {
   it('returns current month + latest non-archived plan', async () => {
-    await insertPlan('current', `${currentMonthPrefix()}-01`)
+    await insertPlan('current', `${monthPrefix()}-01`)
     await insertPlan('future', '2099-12-01')
     await insertPlan('archived', '2099-12-15', { isArchived: true })
     const result = await getSidebarPlans()
     expect(result.currentMonth?.id).toBe('current')
     expect(result.latest?.id).toBe('future')
+  })
+})
+
+describe('getActivePlan', () => {
+  it('returns the current-month plan, not marked as upcoming', async () => {
+    await insertPlan('current', `${monthPrefix()}-01`)
+    const active = await getActivePlan()
+    expect(active?.plan.id).toBe('current')
+    expect(active?.isUpcoming).toBe(false)
+  })
+
+  it('falls back to the nearest upcoming plan, marked as upcoming', async () => {
+    await insertPlan('future', `${monthPrefix(1)}-01`)
+    const active = await getActivePlan()
+    expect(active?.plan.id).toBe('future')
+    expect(active?.isUpcoming).toBe(true)
+  })
+
+  it('returns undefined when no plan exists at all', async () => {
+    expect(await getActivePlan()).toBeUndefined()
   })
 })

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,6 +1,6 @@
 import { db } from '@/db/database'
 import { plan } from '@/db/schema/plans'
-import { and, desc, eq, like, or } from 'drizzle-orm'
+import { and, asc, desc, eq, gte, like, or } from 'drizzle-orm'
 import { buildSetValues } from '@/lib/db/partial-update'
 
 // Infer types from Drizzle schema
@@ -156,11 +156,17 @@ export async function deletePlan(id: string): Promise<boolean> {
 }
 
 /**
+ * Format a date as a `YYYY-MM` month key.
+ */
+export function formatYearMonth(date: Date): string {
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`
+}
+
+/**
  * Get the plan for the current month (if it exists)
  */
 export async function getCurrentMonthPlan(): Promise<Plan | undefined> {
-  const now = new Date()
-  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+  const currentMonth = formatYearMonth(new Date())
 
   return db.query.plan.findFirst({
     where: and(
@@ -168,6 +174,38 @@ export async function getCurrentMonthPlan(): Promise<Plan | undefined> {
       eq(plan.isArchived, false),
     ),
   })
+}
+
+/**
+ * Get the nearest non-archived plan whose date falls in a future month
+ * (strictly after the current calendar month). Used as a dashboard
+ * fallback when no plan exists for the current month.
+ */
+export async function getNextUpcomingPlan(): Promise<Plan | undefined> {
+  const now = new Date()
+  const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1)
+  const cutoff = `${formatYearMonth(nextMonthStart)}-01`
+
+  return db.query.plan.findFirst({
+    where: and(gte(plan.date, cutoff), eq(plan.isArchived, false)),
+    orderBy: asc(plan.date),
+  })
+}
+
+/**
+ * Get the plan to treat as "active": the current month's plan if one
+ * exists, otherwise the nearest upcoming plan.
+ */
+export async function getActivePlan(): Promise<
+  { plan: Plan; isUpcoming: boolean } | undefined
+> {
+  const currentPlan = await getCurrentMonthPlan()
+  if (currentPlan) return { plan: currentPlan, isUpcoming: false }
+
+  const upcomingPlan = await getNextUpcomingPlan()
+  if (upcomingPlan) return { plan: upcomingPlan, isUpcoming: true }
+
+  return undefined
 }
 
 /**


### PR DESCRIPTION
## Summary
- Dashboard now falls back to the nearest upcoming plan when no plan exists for the current month, instead of showing the empty state
- Added `getNextUpcomingPlan` and `getActivePlan` (current-month-or-nearest-upcoming resolver) to `src/lib/plans.ts`
- Balance card shows "Nächster Saldo" + a "Bevorstehend" badge, and the dashboard shows a notice banner, when displaying an upcoming plan instead of the current month's

## Test plan
- [x] `bun test src/lib/plans.test.ts src/lib/dashboard.test.ts` (41 passing, including new coverage for `getNextUpcomingPlan` and `getActivePlan`)
- [x] `bun run lint --type-aware`
- [x] `bun run astro check`
- [x] `bunx vue-tsc --noEmit`
- [x] `bun run fallow` (audit gate clean)
- [ ] Manual check in browser: confirm badge/banner render when no current-month plan exists but a future plan does

🤖 Generated with [Claude Code](https://claude.com/claude-code)