### PR TITLE
fix(dashboard): Monatsübersicht nach Planzugehörigkeit aggregieren

### DIFF
--- a/src/lib/__fixtures__/dates.ts
+++ b/src/lib/__fixtures__/dates.ts
@@ -1,0 +1,18 @@
+/**
+ * Date helpers for tests that depend on "now" (dashboard range queries).
+ *
+ * Deliberately standalone: `formatYearMonth` lives in `@/lib/plans`, which
+ * pulls in `@/db/database` — importing it statically from a fixture would open
+ * the real database before `setupTestDb()` can mock the module.
+ */
+
+/**
+ * `YYYY-MM-DD` in the month `offsetMonths` from the current one.
+ * Positive offsets are in the future, negative ones in the past.
+ */
+export function monthOffsetDate(offsetMonths: number, day = '15'): string {
+  const today = new Date()
+  const d = new Date(today.getFullYear(), today.getMonth() + offsetMonths, 1)
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  return `${d.getFullYear()}-${month}-${day}`
+}

--- a/src/lib/__fixtures__/dates.ts
+++ b/src/lib/__fixtures__/dates.ts
@@ -14,5 +14,5 @@ export function monthOffsetDate(offsetMonths: number, day = '15'): string {
   const today = new Date()
   const d = new Date(today.getFullYear(), today.getMonth() + offsetMonths, 1)
   const month = String(d.getMonth() + 1).padStart(2, '0')
-  return `${d.getFullYear()}-${month}-${day}`
+  return `${d.getFullYear()}-${month}-${day.padStart(2, '0')}`
 }

--- a/src/lib/dashboard.test.ts
+++ b/src/lib/dashboard.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from 'bun:test'
+import { monthOffsetDate } from '@/lib/__fixtures__/dates'
 import {
   seedCategory,
   seedPlan,
@@ -9,17 +10,23 @@ import { setupTestDb } from '@/lib/__fixtures__/test-setup'
 const testDb = setupTestDb()
 
 const { getDashboardStats, getMonthlyChartData } = await import('./dashboard')
-const { formatYearMonth } = await import('./plans')
 
-async function insertPlanForFutureMonth(id = 'plan-future', offsetMonths = 2) {
-  const today = new Date()
-  const d = new Date(today.getFullYear(), today.getMonth() + offsetMonths, 1)
-  await seedPlan(testDb, { id, name: 'Plan', date: `${formatYearMonth(d)}-01` })
+async function insertPlanForMonth(
+  id = 'plan-future',
+  offsetMonths = 2,
+  isArchived = false,
+) {
+  await seedPlan(testDb, {
+    id,
+    name: 'Plan',
+    date: monthOffsetDate(offsetMonths, '01'),
+    isArchived,
+  })
   return id
 }
 
 function insertPlanForCurrentMonth(id = 'plan-current') {
-  return insertPlanForFutureMonth(id, 0)
+  return insertPlanForMonth(id, 0)
 }
 
 async function insertCategory(
@@ -72,7 +79,7 @@ describe('getDashboardStats', () => {
   })
 
   it('falls back to the nearest upcoming plan when there is no current-month plan', async () => {
-    const planId = await insertPlanForFutureMonth()
+    const planId = await insertPlanForMonth()
     await insertCategory('cat-a', 'Miete')
     await insertTransaction({
       id: 't-income',
@@ -103,7 +110,7 @@ describe('getDashboardStats', () => {
 
   it('prefers the current-month plan over a future plan when both exist', async () => {
     const currentId = await insertPlanForCurrentMonth()
-    await insertPlanForFutureMonth()
+    await insertPlanForMonth()
 
     const stats = await getDashboardStats()
     expect(stats.currentPlan?.id).toBe(currentId)
@@ -206,43 +213,78 @@ describe('getMonthlyChartData', () => {
   })
 
   it('aggregates income and expense per month within the range', async () => {
-    const today = new Date()
-    const ym = (offsetMonths: number) => {
-      const d = new Date(
-        today.getFullYear(),
-        today.getMonth() - offsetMonths,
-        1,
-      )
-      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-15`
-    }
+    await insertPlanForMonth('p-prev', -2)
 
     await insertTransaction({
       id: 'tx-now-income',
       planId: 'p1',
       amount: 100000,
       type: 'income',
-      dueDate: ym(0),
+      dueDate: monthOffsetDate(0),
     })
     await insertTransaction({
       id: 'tx-now-expense',
       planId: 'p1',
       amount: 50000,
       type: 'expense',
-      dueDate: ym(0),
+      dueDate: monthOffsetDate(0),
     })
     await insertTransaction({
       id: 'tx-prev-income',
-      planId: 'p1',
+      planId: 'p-prev',
       amount: 80000,
       type: 'income',
-      dueDate: ym(2),
+      dueDate: monthOffsetDate(-2),
     })
 
     const result = await getMonthlyChartData('6m')
-    expect(result.length).toBeGreaterThan(0)
+    expect(result.length).toBe(2)
+    expect(result.at(0)?.income).toBe(80000)
     const currentBucket = result.at(-1)
     expect(currentBucket?.income).toBe(100000)
     expect(currentBucket?.expense).toBe(50000)
+  })
+
+  it('buckets a transaction by its plan month, not by its due date', async () => {
+    await insertTransaction({
+      id: 'tx-stale-due-date',
+      planId: 'p1',
+      amount: 25000,
+      type: 'expense',
+      dueDate: monthOffsetDate(-2),
+    })
+
+    const result = await getMonthlyChartData('6m')
+    expect(result.length).toBe(1)
+    expect(result.at(0)?.expense).toBe(25000)
+  })
+
+  it('ignores transactions that belong to no plan', async () => {
+    await insertTransaction({
+      id: 'tx-orphan',
+      planId: null,
+      amount: 30000,
+      type: 'expense',
+      dueDate: monthOffsetDate(0),
+    })
+
+    const result = await getMonthlyChartData('6m')
+    expect(result).toEqual([])
+  })
+
+  it('includes transactions from archived plans', async () => {
+    await insertPlanForMonth('p-archived', 0, true)
+    await insertTransaction({
+      id: 'tx-archived',
+      planId: 'p-archived',
+      amount: 10000,
+      type: 'expense',
+      dueDate: monthOffsetDate(0),
+    })
+
+    const result = await getMonthlyChartData('6m')
+    expect(result.length).toBe(1)
+    expect(result.at(0)?.expense).toBe(10000)
   })
 
   it('handles 12m range (lookback 11 months)', async () => {

--- a/src/lib/dashboard.ts
+++ b/src/lib/dashboard.ts
@@ -1,5 +1,5 @@
 import { db } from '@/db/database'
-import { plannedTransaction, category } from '@/db/schema/plans'
+import { plannedTransaction, category, plan } from '@/db/schema/plans'
 import { and, asc, count, desc, eq, gte, sql, sum } from 'drizzle-orm'
 import { getActivePlan, type Plan } from '@/lib/plans'
 import { getPlanBalance } from '@/lib/transactions'
@@ -229,26 +229,30 @@ function groupMonthlyRows(rows: MonthRow[]): Map<string, MonthBucket> {
 }
 
 /**
- * Get monthly chart data based on range
+ * Get monthly chart data based on range.
+ *
+ * Buckets by plan membership (the month of the transaction's plan), not by
+ * due date, so a bar always matches the plan balance shown for that month.
+ * Transactions without a plan are not part of any plan view and are ignored;
+ * archived plans still count so past months keep their history.
  */
 export async function getMonthlyChartData(
   range: ChartRange,
 ): Promise<MonthlyChartData[]> {
   const startDate = chartStartDate(range, new Date())
+  const monthExpr = sql<string>`strftime('%Y-%m', ${plan.date})`
 
   const result = await db
     .select({
-      month: sql<string>`strftime('%Y-%m', ${plannedTransaction.dueDate})`,
+      month: monthExpr,
       type: plannedTransaction.type,
       total: sum(plannedTransaction.amount),
     })
     .from(plannedTransaction)
-    .where(gte(plannedTransaction.dueDate, startDate))
-    .groupBy(
-      sql`strftime('%Y-%m', ${plannedTransaction.dueDate})`,
-      plannedTransaction.type,
-    )
-    .orderBy(asc(sql`strftime('%Y-%m', ${plannedTransaction.dueDate})`))
+    .innerJoin(plan, eq(plannedTransaction.planId, plan.id))
+    .where(gte(plan.date, startDate))
+    .groupBy(monthExpr, plannedTransaction.type)
+    .orderBy(asc(monthExpr))
 
   const monthlyMap = groupMonthlyRows(result)
   return Array.from(monthlyMap, ([month, data]) => ({

--- a/src/pages/api/dashboard/chart.test.ts
+++ b/src/pages/api/dashboard/chart.test.ts
@@ -66,7 +66,7 @@ describe('GET /api/dashboard/chart', () => {
   })
 
   it('includes seeded data points in the response', async () => {
-    await seedTx(monthOffsetDate(0), 50000, 'income')
+    await seedTx(monthOffsetDate(0, '01'), 50000, 'income')
     const res = (await GET(
       buildApiContext({ url: 'http://test/api/dashboard/chart' }) as never,
     )) as Response

--- a/src/pages/api/dashboard/chart.test.ts
+++ b/src/pages/api/dashboard/chart.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { monthOffsetDate } from '@/lib/__fixtures__/dates'
 import { seedPlan, seedPlannedTransaction } from '@/lib/__fixtures__/seeds'
 import { setupTestDb } from '@/lib/__fixtures__/test-setup'
 import { buildApiContext } from '@/lib/__fixtures__/api-context'
@@ -7,17 +8,19 @@ const testDb = setupTestDb()
 
 const { GET } = await import('./chart')
 
+/** Seeds a plan dated `date` plus one transaction in it, due on `dueDate`. */
 async function seedTx(
   date: string,
   amount: number,
   type: 'income' | 'expense',
+  dueDate = date,
 ) {
   await seedPlan(testDb, { id: `p-${date}`, date, isArchived: false })
   await seedPlannedTransaction(testDb, {
     id: `t-${date}-${type}`,
     name: 'tx',
     type,
-    dueDate: date,
+    dueDate,
     amount,
     isDone: false,
     isBudget: false,
@@ -63,14 +66,28 @@ describe('GET /api/dashboard/chart', () => {
   })
 
   it('includes seeded data points in the response', async () => {
-    const today = new Date()
-    const ym = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-15`
-    await seedTx(ym, 50000, 'income')
+    await seedTx(monthOffsetDate(0), 50000, 'income')
     const res = (await GET(
       buildApiContext({ url: 'http://test/api/dashboard/chart' }) as never,
     )) as Response
     const body = await res.json()
     expect(body.data.length).toBeGreaterThan(0)
     expect(body.data.at(-1).income).toBe(50000)
+  })
+
+  it('counts a transaction in its plan month, not in its due date month', async () => {
+    await seedTx(
+      monthOffsetDate(0, '01'),
+      12345,
+      'expense',
+      monthOffsetDate(-1),
+    )
+
+    const res = (await GET(
+      buildApiContext({ url: 'http://test/api/dashboard/chart' }) as never,
+    )) as Response
+    const body = await res.json()
+    expect(body.data.length).toBe(1)
+    expect(body.data.at(-1).expense).toBe(12345)
   })
 })


### PR DESCRIPTION
## Problem

Die Balken der Monatsübersicht wichen von den Zahlen des Plans ab — in Produktion um 294,76 € bei den Ausgaben für Juli 2026, während die Einnahmen exakt stimmten.

Ursache: `getMonthlyChartData` war die einzige Stelle des Dashboards, die **nicht** nach Planzugehörigkeit aggregiert hat. Sie gruppierte über `strftime('%Y-%m', planned_transaction.due_date)` ganz ohne Join auf `plan`, während `getPlanBalance` (Saldo-Card und Planseite) über `WHERE plan_id = …` geht.

Sobald das Fälligkeitsdatum einer Transaktion nicht im Monat ihres Plans liegt, laufen beide Zahlen auseinander. Das passiert im Normalbetrieb: beim Verschieben in einen anderen Plan bleibt das Datum stehen, und manuell eingegebene Daten sind an keinen Planmonat gebunden. Zusätzlich hat der Chart archivierte und doppelte Pläne mitgezählt, die Card nie.

## Änderung

`getMonthlyChartData` joint jetzt `plan` und gruppiert über den Monat des Plans. Ein Balken ist damit per Konstruktion identisch mit dem Saldo des Plans dieses Monats.

Zwei bewusste Nebeneffekte:

- Transaktionen ohne Plan fallen durch den Inner Join raus — sie sind in keiner Plan- oder Dashboard-Ansicht sichtbar.
- Archivierte Pläne zählen weiter mit, sonst würden ältere Monate aus dem Chart verschwinden, sobald sie archiviert werden.

API-Signatur und Response-Form bleiben unverändert, `DashboardMonthlyChart.vue` ist nicht betroffen.

## Tests

Regressionstest „buckets a transaction by its plan month, not by its due date" plus Fälle für Transaktionen ohne Plan und für archivierte Pläne. Der bestehende Mehr-Monats-Test hing alle Transaktionen an denselben Plan und trennte sie nur über die Fälligkeit — er verteilt sie jetzt auf zwei Pläne. Die Datums-Helfer der Tests sind in `src/lib/__fixtures__/dates.ts` zusammengeführt.

`bun test` (606 pass), `oxlint --type-aware`, `astro check` (0 Fehler), `fallow audit` (Duplication 0, Complexity 0) sind grün.

## Offen (nicht Teil dieses PRs)

Was die inkonsistenten Daten erzeugt, bleibt bestehen:

- `TransactionMoveDialog` schickt beim Planwechsel nur `planId`; das `due_date` könnte über das vorhandene `adjustDueDateToMonth()` in den Zielmonat gezogen werden.
- `getCurrentMonthPlan()` nutzt `findFirst` ohne `orderBy` und wählt bei zwei aktiven Plänen desselben Monats willkürlich aus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
