### PR TITLE
feat(api): API-Zugriff über benutzererstellte API-Keys

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@astrojs/check": "0.9.10",
         "@astrojs/node": "11.1.0",
         "@astrojs/vue": "7.0.2",
+        "@better-auth/api-key": "1.6.26",
         "@better-auth/drizzle-adapter": "1.6.26",
         "@better-auth/passkey": "1.6.26",
         "@lowlighter/qrcode": "^3.1.0",
@@ -165,6 +166,8 @@
     "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@better-auth/api-key": ["@better-auth/api-key@1.6.26", "", { "dependencies": { "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/core": "^1.6.26", "@better-auth/utils": "0.4.2", "better-auth": "^1.6.26", "better-call": "1.3.7" } }, "sha512-8Sjsk3I2grcgwIkaF/elgLbU/QtDAkN3RCFtBpK8FKY6CD5k9xZ3p3n5B0aQKzGrTXzc9QMPnsRphCn3CgATbg=="],
 
     "@better-auth/core": ["@better-auth/core@1.6.26", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.2", "@better-fetch/fetch": "1.3.1", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.7", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-Ud4FqnjIJDvmeo+3bN+OsuVVAiuvFjNERbW7G8/65ictSxCox62gNgTOsJ4YXmbwXzBzyyekStzrupg2qNGEkA=="],
 

--- a/drizzle/0020_kind_ego.sql
+++ b/drizzle/0020_kind_ego.sql
@@ -1,0 +1,27 @@
+CREATE TABLE `apikey` (
+	`id` text PRIMARY KEY NOT NULL,
+	`config_id` text NOT NULL,
+	`name` text,
+	`start` text,
+	`prefix` text,
+	`key` text NOT NULL,
+	`reference_id` text NOT NULL,
+	`refill_interval` integer,
+	`refill_amount` integer,
+	`last_refill_at` integer,
+	`enabled` integer DEFAULT true,
+	`rate_limit_enabled` integer DEFAULT true,
+	`rate_limit_time_window` integer,
+	`rate_limit_max` integer,
+	`request_count` integer,
+	`remaining` integer,
+	`last_request` integer,
+	`expires_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`permissions` text,
+	`metadata` text
+);
+--> statement-breakpoint
+CREATE INDEX `apikey_referenceId_idx` ON `apikey` (`reference_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `apikey_key_idx` ON `apikey` (`key`);

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2175 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "54aa1202-33e1-4ccb-9db4-aa97ad810672",
+  "prevId": "c781c63a-2a8e-4d40-8842-326f592bd18f",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_id": {
+          "name": "config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refill_interval": {
+          "name": "refill_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refill_amount": {
+          "name": "refill_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_refill_at": {
+          "name": "last_refill_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_enabled": {
+          "name": "rate_limit_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "rate_limit_time_window": {
+          "name": "rate_limit_time_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_max": {
+          "name": "rate_limit_max",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_request": {
+          "name": "last_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_referenceId_idx": {
+          "name": "apikey_referenceId_idx",
+          "columns": [
+            "reference_id"
+          ],
+          "isUnique": false
+        },
+        "apikey_key_idx": {
+          "name": "apikey_key_idx",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "twoFactor_userId_idx": {
+          "name": "twoFactor_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bank_transaction": {
+      "name": "bank_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_import_id": {
+          "name": "first_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_import_id": {
+          "name": "last_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_transaction_id": {
+          "name": "external_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_date": {
+          "name": "booking_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'EUR'"
+        },
+        "original_amount_cents": {
+          "name": "original_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_currency": {
+          "name": "original_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "counterparty": {
+          "name": "counterparty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_text": {
+          "name": "booking_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "balance_after_cents": {
+          "name": "balance_after_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "balance_currency": {
+          "name": "balance_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cardholder": {
+          "name": "cardholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_data_json": {
+          "name": "raw_data_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_assignment": {
+          "name": "plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_split_budget_id": {
+          "name": "pre_split_budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "import_seen_count": {
+          "name": "import_seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bankTransaction_sourceId_dedupeKey_idx": {
+          "name": "bankTransaction_sourceId_dedupeKey_idx",
+          "columns": [
+            "source_id",
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "bankTransaction_bookingDate_idx": {
+          "name": "bankTransaction_bookingDate_idx",
+          "columns": [
+            "booking_date"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_planId_idx": {
+          "name": "bankTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_status_idx": {
+          "name": "bankTransaction_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_externalTransactionId_idx": {
+          "name": "bankTransaction_externalTransactionId_idx",
+          "columns": [
+            "external_transaction_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_isArchived_idx": {
+          "name": "bankTransaction_isArchived_idx",
+          "columns": [
+            "is_archived"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_isSplit_idx": {
+          "name": "bankTransaction_isSplit_idx",
+          "columns": [
+            "is_split"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_budgetId_idx": {
+          "name": "bankTransaction_budgetId_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_preSplitBudgetId_idx": {
+          "name": "bankTransaction_preSplitBudgetId_idx",
+          "columns": [
+            "pre_split_budget_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bank_transaction_source_id_import_source_id_fk": {
+          "name": "bank_transaction_source_id_import_source_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_first_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_first_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "first_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_last_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_last_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "last_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_plan_id_plan_id_fk": {
+          "name": "bank_transaction_plan_id_plan_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_budget_id_planned_transaction_id_fk": {
+          "name": "bank_transaction_budget_id_planned_transaction_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_pre_split_budget_id_planned_transaction_id_fk": {
+          "name": "bank_transaction_pre_split_budget_id_planned_transaction_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "pre_split_budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bank_transaction_split": {
+      "name": "bank_transaction_split",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_transaction_id": {
+          "name": "bank_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bankTransactionSplit_bankTransactionId_idx": {
+          "name": "bankTransactionSplit_bankTransactionId_idx",
+          "columns": [
+            "bank_transaction_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransactionSplit_budgetId_idx": {
+          "name": "bankTransactionSplit_budgetId_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransactionSplit_planId_idx": {
+          "name": "bankTransactionSplit_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransactionSplit_isArchived_idx": {
+          "name": "bankTransactionSplit_isArchived_idx",
+          "columns": [
+            "is_archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bank_transaction_split_bank_transaction_id_bank_transaction_id_fk": {
+          "name": "bank_transaction_split_bank_transaction_id_bank_transaction_id_fk",
+          "tableFrom": "bank_transaction_split",
+          "tableTo": "bank_transaction",
+          "columnsFrom": [
+            "bank_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_split_budget_id_planned_transaction_id_fk": {
+          "name": "bank_transaction_split_budget_id_planned_transaction_id_fk",
+          "tableFrom": "bank_transaction_split",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_split_plan_id_plan_id_fk": {
+          "name": "bank_transaction_split_plan_id_plan_id_fk",
+          "tableFrom": "bank_transaction_split",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category": {
+      "name": "category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "category_name_idx": {
+          "name": "category_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "category_slug_idx": {
+          "name": "category_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_source": {
+      "name": "import_source",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_label": {
+          "name": "account_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_identifier": {
+          "name": "account_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_plan_assignment": {
+          "name": "default_plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto_month'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "importSource_preset_idx": {
+          "name": "importSource_preset_idx",
+          "columns": [
+            "preset"
+          ],
+          "isUnique": false
+        },
+        "importSource_isActive_idx": {
+          "name": "importSource_isActive_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan": {
+      "name": "plan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plan_date_idx": {
+          "name": "plan_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "planned_transaction": {
+      "name": "planned_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_done": {
+          "name": "is_done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_budget": {
+          "name": "is_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plannedTransaction_planId_idx": {
+          "name": "plannedTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_userId_idx": {
+          "name": "plannedTransaction_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_dueDate_idx": {
+          "name": "plannedTransaction_dueDate_idx",
+          "columns": [
+            "due_date"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_categoryId_idx": {
+          "name": "plannedTransaction_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_type_idx": {
+          "name": "plannedTransaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "planned_transaction_plan_id_plan_id_fk": {
+          "name": "planned_transaction_plan_id_plan_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_user_id_user_id_fk": {
+          "name": "planned_transaction_user_id_user_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_category_id_category_id_fk": {
+          "name": "planned_transaction_category_id_category_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "statement_import": {
+      "name": "statement_import",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_sha256": {
+          "name": "file_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preview_count": {
+          "name": "preview_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "statementImport_sourceId_idx": {
+          "name": "statementImport_sourceId_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "statementImport_fileSha256_idx": {
+          "name": "statementImport_fileSha256_idx",
+          "columns": [
+            "file_sha256"
+          ],
+          "isUnique": false
+        },
+        "statementImport_createdAt_idx": {
+          "name": "statementImport_createdAt_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "statement_import_source_id_import_source_id_fk": {
+          "name": "statement_import_source_id_import_source_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_import_triggered_by_user_id_user_id_fk": {
+          "name": "statement_import_triggered_by_user_id_user_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_preset": {
+      "name": "transaction_preset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'einmalig'"
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_budget": {
+          "name": "is_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionPreset_userId_idx": {
+          "name": "transactionPreset_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_categoryId_idx": {
+          "name": "transactionPreset_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_type_idx": {
+          "name": "transactionPreset_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_recurrence_idx": {
+          "name": "transactionPreset_recurrence_idx",
+          "columns": [
+            "recurrence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_preset_user_id_user_id_fk": {
+          "name": "transaction_preset_user_id_user_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_preset_category_id_category_id_fk": {
+          "name": "transaction_preset_category_id_category_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_setting": {
+      "name": "user_setting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userSetting_userId_key_idx": {
+          "name": "userSetting_userId_key_idx",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_setting_user_id_user_id_fk": {
+          "name": "user_setting_user_id_user_id_fk",
+          "tableFrom": "user_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1786721639668,
       "tag": "0019_mute_killraven",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1786723622427,
+      "tag": "0020_kind_ego",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@astrojs/check": "0.9.10",
     "@astrojs/node": "11.1.0",
     "@astrojs/vue": "7.0.2",
+    "@better-auth/api-key": "1.6.26",
     "@better-auth/drizzle-adapter": "1.6.26",
     "@better-auth/passkey": "1.6.26",
     "@lowlighter/qrcode": "^3.1.0",

--- a/src/components/ApiKeyManager.vitest.ts
+++ b/src/components/ApiKeyManager.vitest.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const listMock = vi.fn()
+const createMock = vi.fn()
+const deleteMock = vi.fn()
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    apiKey: {
+      list: (...args: unknown[]) => listMock(...args),
+      create: (...args: unknown[]) => createMock(...args),
+      delete: (...args: unknown[]) => deleteMock(...args),
+    },
+  },
+}))
+
+const ApiKeyManager = (await import('./ApiKeyManager.vue')).default
+
+beforeEach(() => {
+  listMock.mockReset()
+  createMock.mockReset()
+  deleteMock.mockReset()
+  listMock.mockResolvedValue({ data: { apiKeys: [] }, error: null })
+})
+
+describe('ApiKeyManager.vue', () => {
+  it('shows the empty state when no keys exist', async () => {
+    const wrapper = mount(ApiKeyManager)
+    await flushPromises()
+    expect(wrapper.text()).toContain('Sie haben noch keine API-Schlüssel')
+  })
+
+  it('renders name and starting characters of existing keys', async () => {
+    listMock.mockResolvedValue({
+      data: {
+        apiKeys: [
+          {
+            id: 'k1',
+            name: 'CI-Zugriff',
+            start: 'dt_abc',
+            createdAt: '2026-03-09T10:00:00.000Z',
+          },
+        ],
+      },
+      error: null,
+    })
+    const wrapper = mount(ApiKeyManager)
+    await flushPromises()
+    expect(wrapper.text()).toContain('CI-Zugriff')
+    expect(wrapper.text()).toContain('dt_abc')
+  })
+
+  it('refuses to create a key without a name', async () => {
+    const wrapper = mount(ApiKeyManager)
+    await flushPromises()
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    expect(createMock).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('Bitte geben Sie einen Namen')
+  })
+
+  it('creates a key and reveals the plaintext exactly once', async () => {
+    createMock.mockResolvedValue({
+      data: { id: 'k1', key: 'dt_plaintextkey' },
+      error: null,
+    })
+    const wrapper = mount(ApiKeyManager, { attachTo: document.body })
+    await flushPromises()
+
+    await wrapper.find('input').setValue('Mein Schlüssel')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+    await flushPromises()
+
+    expect(createMock).toHaveBeenCalledWith({ name: 'Mein Schlüssel' })
+    expect(document.body.textContent).toContain('dt_plaintextkey')
+    // Name input is cleared and the list is refreshed after creation.
+    expect(listMock).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('surfaces a German error when creation fails', async () => {
+    createMock.mockResolvedValue({ data: null, error: { message: 'nope' } })
+    const wrapper = mount(ApiKeyManager)
+    await flushPromises()
+
+    await wrapper.find('input').setValue('Fehlerschlüssel')
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('konnte nicht erstellt werden')
+  })
+
+  it('surfaces a German error when the list request fails', async () => {
+    listMock.mockResolvedValue({ data: null, error: { message: 'nope' } })
+    const wrapper = mount(ApiKeyManager)
+    await flushPromises()
+    expect(wrapper.text()).toContain('konnten nicht geladen werden')
+  })
+})

--- a/src/components/ApiKeyManager.vue
+++ b/src/components/ApiKeyManager.vue
@@ -1,0 +1,257 @@
+<script setup lang="ts">
+import { computed, ref, onMounted } from 'vue'
+import { useClipboard } from '@vueuse/core'
+import { formatDateTime } from '@/lib/format'
+import { authClient } from '@/lib/auth-client'
+import { useAuthAction } from '@/composables/useAuthAction'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Check, Copy, KeyRound, Loader2, Plus, Trash2 } from 'lucide-vue-next'
+
+interface ApiKeyItem {
+  id: string
+  name: string | null
+  start: string | null
+  createdAt: string | Date
+}
+
+/** Matches the plugin's default `maximumNameLength`. */
+const MAX_NAME_LENGTH = 32
+
+const apiKeys = ref<ApiKeyItem[]>([])
+const newKeyName = ref('')
+const createdKey = ref<string | null>(null)
+const { copy: copyCreatedKey, copied: hasCopied } = useClipboard()
+
+const {
+  isLoading: isListLoading,
+  errorMessage: listError,
+  runWithErrorHandling: runListAction,
+} = useAuthAction()
+
+// Creating and revoking share one action so the list keeps rendering while a
+// mutation is in flight; only the initial/refreshing list swaps in a spinner.
+const {
+  isLoading: isMutating,
+  errorMessage: mutationError,
+  runWithErrorHandling: runMutation,
+} = useAuthAction()
+
+const nameError = ref<string | null>(null)
+const hasLoadedOnce = ref(false)
+
+const errorMessage = computed(
+  () => nameError.value ?? mutationError.value ?? listError.value,
+)
+/** The first render happens before `onMounted` fires, so show the spinner. */
+const isListPending = computed(
+  () => !hasLoadedOnce.value || isListLoading.value,
+)
+
+async function loadApiKeys() {
+  const data = await runListAction(() => authClient.apiKey.list(), {
+    default: 'API-Schlüssel konnten nicht geladen werden.',
+  })
+  hasLoadedOnce.value = true
+  if (data) {
+    apiKeys.value = (data.apiKeys ?? []) as unknown as ApiKeyItem[]
+  }
+}
+
+async function createApiKey() {
+  const name = newKeyName.value.trim()
+  if (!name) {
+    nameError.value = 'Bitte geben Sie einen Namen für den Schlüssel an.'
+    return
+  }
+  nameError.value = null
+
+  const data = await runMutation(() => authClient.apiKey.create({ name }), {
+    default: 'API-Schlüssel konnte nicht erstellt werden.',
+  })
+  if (!data) return
+
+  createdKey.value = data.key
+  newKeyName.value = ''
+  await loadApiKeys()
+}
+
+async function deleteApiKey(keyId: string) {
+  nameError.value = null
+
+  const data = await runMutation(() => authClient.apiKey.delete({ keyId }), {
+    default: 'API-Schlüssel konnte nicht widerrufen werden.',
+  })
+  if (!data) return
+
+  apiKeys.value = apiKeys.value.filter((item) => item.id !== keyId)
+}
+
+function keyMeta(item: ApiKeyItem): string {
+  const created = `Erstellt am ${formatDateTime(item.createdAt)}`
+  return item.start ? `${item.start}… · ${created}` : created
+}
+
+onMounted(() => {
+  loadApiKeys()
+})
+</script>
+
+<template>
+  <Card>
+    <CardHeader>
+      <CardTitle class="flex items-center gap-2">
+        <KeyRound class="size-5" />
+        API-Schlüssel
+      </CardTitle>
+      <CardDescription>
+        Erstellen Sie Schlüssel für den lesenden Zugriff auf die API. Senden Sie
+        den Schlüssel als Header
+        <code class="bg-muted rounded px-1 py-0.5 text-xs">x-api-key</code> bei
+        GET-Anfragen an
+        <code class="bg-muted rounded px-1 py-0.5 text-xs">/api/…</code>.
+        Ändernde Anfragen sind mit API-Schlüsseln nicht möglich.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <div
+        v-if="errorMessage"
+        class="bg-destructive/10 text-destructive mb-4 rounded-md p-3 text-sm"
+      >
+        {{ errorMessage }}
+      </div>
+
+      <form class="mb-4 flex items-center gap-2" @submit.prevent="createApiKey">
+        <Input
+          v-model="newKeyName"
+          :maxlength="MAX_NAME_LENGTH"
+          placeholder="Name des Schlüssels"
+          aria-label="Name des Schlüssels"
+          class="max-w-xs"
+        />
+        <Button type="submit" :disabled="isMutating">
+          <Loader2 v-if="isMutating" class="size-4 animate-spin" />
+          <Plus v-else class="size-4" />
+          Schlüssel erstellen
+        </Button>
+      </form>
+
+      <div v-if="isListPending" class="flex items-center justify-center py-8">
+        <Loader2 class="text-muted-foreground size-6 animate-spin" />
+      </div>
+
+      <div v-else-if="apiKeys.length === 0" class="py-8 text-center">
+        <KeyRound class="text-muted-foreground mx-auto mb-4 size-12" />
+        <p class="text-muted-foreground">
+          Sie haben noch keine API-Schlüssel erstellt.
+        </p>
+      </div>
+
+      <div v-else class="space-y-3">
+        <div
+          v-for="apiKey in apiKeys"
+          :key="apiKey.id"
+          class="bg-muted/50 flex items-center justify-between rounded-lg p-4"
+        >
+          <div class="flex items-center gap-4">
+            <KeyRound class="text-muted-foreground size-8" />
+            <div>
+              <p class="font-medium">
+                {{ apiKey.name ?? 'Unbenannter Schlüssel' }}
+              </p>
+              <p class="text-muted-foreground text-sm">
+                {{ keyMeta(apiKey) }}
+              </p>
+            </div>
+          </div>
+          <AlertDialog>
+            <AlertDialogTrigger as-child>
+              <Button size="icon" variant="ghost" title="Widerrufen">
+                <Trash2 class="size-4" />
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>API-Schlüssel widerrufen?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Möchten Sie diesen Schlüssel wirklich widerrufen? Anwendungen,
+                  die ihn verwenden, verlieren sofort den Zugriff.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Abbrechen</AlertDialogCancel>
+                <AlertDialogAction @click="deleteApiKey(apiKey.id)">
+                  Widerrufen
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </div>
+    </CardContent>
+  </Card>
+
+  <Dialog
+    :open="createdKey !== null"
+    @update:open="(open: boolean) => !open && (createdKey = null)"
+  >
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>Neuer API-Schlüssel</DialogTitle>
+        <DialogDescription>
+          Kopieren Sie den Schlüssel jetzt. Er wird aus Sicherheitsgründen nur
+          ein einziges Mal angezeigt.
+        </DialogDescription>
+      </DialogHeader>
+      <div class="flex items-center gap-2">
+        <code
+          class="bg-muted flex-1 overflow-x-auto rounded-md p-3 font-mono text-sm break-all"
+        >
+          {{ createdKey }}
+        </code>
+        <Button
+          size="icon"
+          variant="outline"
+          title="Schlüssel kopieren"
+          @click="copyCreatedKey(createdKey!)"
+        >
+          <Check v-if="hasCopied" class="size-4" />
+          <Copy v-else class="size-4" />
+        </Button>
+      </div>
+      <!-- Empty until something was copied; the slot keeps its height either way. -->
+      <p class="text-muted-foreground min-h-5 text-sm">
+        {{ hasCopied ? 'Schlüssel wurde in die Zwischenablage kopiert.' : '' }}
+      </p>
+      <DialogFooter>
+        <Button @click="createdKey = null">Fertig</Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -1,5 +1,11 @@
 import { relations } from 'drizzle-orm'
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core'
 import { timestamps } from './_columns'
 
 export const user = sqliteTable('user', {
@@ -116,6 +122,45 @@ export const twoFactor = sqliteTable(
       .references(() => user.id, { onDelete: 'cascade' }),
   },
   (table) => [index('twoFactor_userId_idx').on(table.userId)],
+)
+
+/**
+ * Mirrors the `apikey` model of the official `@better-auth/api-key` plugin.
+ * Field names/types are derived from the plugin's `apiKeySchema` definition.
+ * `referenceId` intentionally has no foreign key: the plugin supports both user
+ * and organization references and declares no relation itself.
+ */
+export const apikey = sqliteTable(
+  'apikey',
+  {
+    id: text('id').primaryKey(),
+    configId: text('config_id').notNull(),
+    name: text('name'),
+    start: text('start'),
+    prefix: text('prefix'),
+    key: text('key').notNull(),
+    referenceId: text('reference_id').notNull(),
+    refillInterval: integer('refill_interval'),
+    refillAmount: integer('refill_amount'),
+    lastRefillAt: integer('last_refill_at', { mode: 'timestamp_ms' }),
+    enabled: integer('enabled', { mode: 'boolean' }).default(true),
+    rateLimitEnabled: integer('rate_limit_enabled', {
+      mode: 'boolean',
+    }).default(true),
+    rateLimitTimeWindow: integer('rate_limit_time_window'),
+    rateLimitMax: integer('rate_limit_max'),
+    requestCount: integer('request_count'),
+    remaining: integer('remaining'),
+    lastRequest: integer('last_request', { mode: 'timestamp_ms' }),
+    expiresAt: integer('expires_at', { mode: 'timestamp_ms' }),
+    ...timestamps(),
+    permissions: text('permissions'),
+    metadata: text('metadata'),
+  },
+  (table) => [
+    index('apikey_referenceId_idx').on(table.referenceId),
+    uniqueIndex('apikey_key_idx').on(table.key),
+  ],
 )
 
 export const sessionRelations = relations(session, ({ one }) => ({

--- a/src/lib/__fixtures__/test-db.ts
+++ b/src/lib/__fixtures__/test-db.ts
@@ -79,6 +79,34 @@ const DDL = `
 
   CREATE UNIQUE INDEX "userSetting_userId_key_idx" ON "user_setting"("user_id","key");
 
+  CREATE TABLE "apikey" (
+    "id" text PRIMARY KEY NOT NULL,
+    "config_id" text NOT NULL,
+    "name" text,
+    "start" text,
+    "prefix" text,
+    "key" text NOT NULL,
+    "reference_id" text NOT NULL,
+    "refill_interval" integer,
+    "refill_amount" integer,
+    "last_refill_at" integer,
+    "enabled" integer DEFAULT true,
+    "rate_limit_enabled" integer DEFAULT true,
+    "rate_limit_time_window" integer,
+    "rate_limit_max" integer,
+    "request_count" integer,
+    "remaining" integer,
+    "last_request" integer,
+    "expires_at" integer,
+    "created_at" integer NOT NULL,
+    "updated_at" integer NOT NULL,
+    "permissions" text,
+    "metadata" text
+  );
+
+  CREATE INDEX "apikey_referenceId_idx" ON "apikey"("reference_id");
+  CREATE UNIQUE INDEX "apikey_key_idx" ON "apikey"("key");
+
   CREATE TABLE "category" (
     "id" text PRIMARY KEY NOT NULL,
     "name" text NOT NULL,
@@ -233,6 +261,7 @@ const TRUNCATE_ORDER = [
   'verification',
   'account',
   'session',
+  'apikey',
   'user',
 ] as const
 

--- a/src/lib/api-key-auth.test.ts
+++ b/src/lib/api-key-auth.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from '@better-auth/drizzle-adapter'
+import { apiKey } from '@better-auth/api-key'
+import * as authSchema from '@/db/schema/auth'
+import { seedUser as seedUserRow } from '@/lib/__fixtures__/seeds'
+import { setupTestDb } from '@/lib/__fixtures__/test-setup'
+
+const testDb = setupTestDb()
+
+/**
+ * Real `betterAuth` instance wired to the in-memory test database.
+ *
+ * The plugin options mirror `src/lib/auth.ts` on purpose: this suite exists to
+ * prove that the official `@better-auth/api-key` plugin can read and write the
+ * Drizzle `apikey` table declared in `src/db/schema/auth.ts`, so the options
+ * must match what production uses.
+ */
+const auth = betterAuth({
+  database: drizzleAdapter(testDb, {
+    provider: 'sqlite',
+    schema: authSchema,
+  }),
+  appName: 'DimeTime',
+  secret: 'test-secret-for-api-key-integration-tests',
+  plugins: [
+    apiKey({
+      enableSessionForAPIKeys: true,
+      requireName: true,
+      defaultPrefix: 'dt_',
+      rateLimit: {
+        enabled: true,
+        timeWindow: 60_000,
+        maxRequests: 100,
+      },
+    }),
+  ],
+})
+
+const userId = 'u-1'
+
+function apiKeyHeaders(key: string): Headers {
+  return new Headers({ 'x-api-key': key })
+}
+
+function createKey(name = 'Test') {
+  return auth.api.createApiKey({ body: { name, userId } })
+}
+
+/** `getSession` either resolves to `null` or throws for a key it rejects. */
+async function resolveSessionOrNull(key: string) {
+  try {
+    return await auth.api.getSession({ headers: apiKeyHeaders(key) })
+  } catch {
+    return null
+  }
+}
+
+beforeEach(async () => {
+  await seedUserRow(testDb, {
+    id: userId,
+    name: 'Tester',
+    email: 'tester@example.com',
+  })
+})
+
+describe('api-key plugin ↔ Drizzle schema', () => {
+  it('creates a key with the dt_ prefix and persists it in the apikey table', async () => {
+    const created = await createKey()
+
+    expect(created.key.startsWith('dt_')).toBe(true)
+    expect(created.name).toBe('Test')
+    expect(created.referenceId).toBe(userId)
+
+    const rows = await testDb
+      .select()
+      .from(authSchema.apikey)
+      .where(eq(authSchema.apikey.id, created.id))
+
+    expect(rows).toHaveLength(1)
+    const row = rows[0]!
+    expect(row.name).toBe('Test')
+    expect(row.referenceId).toBe(userId)
+    expect(row.prefix).toBe('dt_')
+    expect(row.start).toBe(created.key.slice(0, 6))
+    expect(row.configId).toBe('default')
+    expect(row.enabled).toBe(true)
+    expect(row.rateLimitEnabled).toBe(true)
+    expect(row.rateLimitTimeWindow).toBe(60_000)
+    expect(row.rateLimitMax).toBe(100)
+    expect(row.requestCount).toBe(0)
+    expect(row.createdAt).toBeInstanceOf(Date)
+    expect(row.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('stores the key hashed, never in plaintext', async () => {
+    const { key } = await createKey()
+
+    const rows = await testDb.select().from(authSchema.apikey)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.key).not.toBe(key)
+    expect(rows[0]!.key).not.toContain(key)
+  })
+})
+
+describe('api-key session resolution', () => {
+  it('resolves a session for a valid key passed as x-api-key', async () => {
+    const { key } = await createKey()
+
+    const session = await auth.api.getSession({ headers: apiKeyHeaders(key) })
+
+    expect(session).not.toBeNull()
+    expect(session?.user.id).toBe(userId)
+  })
+
+  it('does not resolve a session for an unknown key of plausible length', async () => {
+    const { key } = await createKey()
+    const wrongKey = `dt_${'a'.repeat(key.length - 3)}`
+    expect(wrongKey.length).toBe(key.length)
+
+    expect(await resolveSessionOrNull(wrongKey)).toBeNull()
+  })
+
+  it('does not resolve a session for a too-short key', async () => {
+    expect(await resolveSessionOrNull('dt_short')).toBeNull()
+  })
+
+  it('stops resolving a session once the key row is revoked', async () => {
+    const { id, key } = await createKey()
+
+    const before = await auth.api.getSession({ headers: apiKeyHeaders(key) })
+    expect(before?.user.id).toBe(userId)
+
+    await testDb.delete(authSchema.apikey).where(eq(authSchema.apikey.id, id))
+
+    expect(await resolveSessionOrNull(key)).toBeNull()
+  })
+})
+
+describe('listApiKeys', () => {
+  it('lists the key metadata without ever exposing the plaintext key', async () => {
+    const { id, key } = await createKey('Mein Schlüssel')
+
+    const listed = await auth.api.listApiKeys({ headers: apiKeyHeaders(key) })
+
+    expect(listed.apiKeys).toHaveLength(1)
+    const entry = listed.apiKeys[0]!
+    expect(entry.id).toBe(id)
+    expect(entry.name).toBe('Mein Schlüssel')
+    expect(entry.start).toBe(key.slice(0, 6))
+    expect(JSON.stringify(listed)).not.toContain(key)
+  })
+})

--- a/src/lib/api-key-auth.ts
+++ b/src/lib/api-key-auth.ts
@@ -1,0 +1,97 @@
+import type { APIContext, MiddlewareNext } from 'astro'
+import { auth } from '@/lib/auth'
+import { AUTH_API_PREFIX, jsonAuthError } from '@/lib/auth-http'
+
+type Session = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>
+
+const READ_ONLY_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
+
+/**
+ * The rate limiter rejects with `details.tryAgainIn` in milliseconds; surface it
+ * as a `Retry-After` header (whole seconds, as the header requires).
+ */
+function retryAfterHeaders(error: unknown): Record<string, string> | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const details = (error as { body?: { details?: unknown } | null }).body
+    ?.details
+  if (typeof details !== 'object' || details === null) return undefined
+  const { tryAgainIn } = details as { tryAgainIn?: unknown }
+  if (typeof tryAgainIn !== 'number' || !Number.isFinite(tryAgainIn)) {
+    return undefined
+  }
+  return { 'Retry-After': String(Math.max(1, Math.ceil(tryAgainIn / 1000))) }
+}
+
+/**
+ * Map a `getSession` failure on the API-key path onto a response. A throttled
+ * key must not look like a revoked one, and a server-side fault must not be
+ * reported as an authentication problem, so only genuine client-side auth
+ * failures keep the 401.
+ *
+ * better-auth's `APIError` always carries a numeric `statusCode`; anything else
+ * that lands here is an unexpected fault and is reported as a 500.
+ */
+function apiKeySessionErrorResponse(error: unknown): Response {
+  const status = (error as { statusCode?: unknown } | null)?.statusCode
+  if (status === 429) {
+    return jsonAuthError('Zu viele Anfragen', 429, retryAfterHeaders(error))
+  }
+  if (typeof status !== 'number' || status >= 500) {
+    return jsonAuthError('Interner Serverfehler', 500)
+  }
+  return jsonAuthError('Ungültiger API-Schlüssel', 401)
+}
+
+/**
+ * A blank or whitespace-only header is ignored by the API-key plugin, which
+ * would make `getSession` silently fall back to the session cookie inside the
+ * 2FA-exempt key path. Treat such headers as absent.
+ */
+export function hasApiKeyHeader(request: Request): boolean {
+  const header = request.headers.get('x-api-key')
+  return header !== null && header.trim() !== ''
+}
+
+/**
+ * Auth path for requests carrying an `x-api-key` header.
+ *
+ * API keys grant read-only access to the `/api/*` surface. They can never be
+ * used for mutating requests, for page routes or for the `/api/auth/*` surface
+ * (so a key can neither create nor revoke keys). Because a key cannot perform
+ * a TOTP challenge, the 2FA-setup gate is skipped for key-authenticated
+ * requests.
+ */
+export async function handleApiKeyRequest(
+  context: APIContext,
+  next: MiddlewareNext,
+) {
+  if (!READ_ONLY_METHODS.has(context.request.method)) {
+    return jsonAuthError('API-Schlüssel erlauben nur Lesezugriff', 403)
+  }
+
+  const { pathname } = context.url
+  if (!pathname.startsWith('/api/') || pathname.startsWith(AUTH_API_PREFIX)) {
+    return jsonAuthError('API-Schlüssel sind nur für API-Endpunkte gültig', 403)
+  }
+
+  let session: Session | null = null
+  try {
+    session = await auth.api.getSession({ headers: context.request.headers })
+  } catch (error) {
+    return apiKeySessionErrorResponse(error)
+  }
+  if (!session) return jsonAuthError('Ungültiger API-Schlüssel', 401)
+
+  // Banning a user revokes their database sessions but leaves `apikey` rows in
+  // place, and the plugin reconstructs a session from the key without ever
+  // consulting the `banned` flag. Check it here so a ban takes effect
+  // immediately instead of only after every key has been revoked.
+  const user = session.user as { banned?: boolean | null }
+  if (user.banned) return jsonAuthError('Benutzerkonto ist gesperrt', 403)
+
+  // No `userSettings` lookup: they are only read while rendering a page, and
+  // key requests never reach one (every non-`/api/` path is rejected above).
+  context.locals.user = session.user
+  context.locals.session = session.session
+  return next()
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,10 +1,12 @@
 import { createAuthClient } from 'better-auth/vue'
 import { passkeyClient } from '@better-auth/passkey/client'
+import { apiKeyClient } from '@better-auth/api-key/client'
 import { twoFactorClient } from 'better-auth/client/plugins'
 
 export const authClient = createAuthClient({
   plugins: [
     passkeyClient(),
+    apiKeyClient(),
     twoFactorClient({
       onTwoFactorRedirect() {
         // Preserve redirectTo parameter from current URL

--- a/src/lib/auth-http.ts
+++ b/src/lib/auth-http.ts
@@ -1,0 +1,18 @@
+/**
+ * HTTP primitives shared by the auth middleware and its extracted guards.
+ */
+
+/** Prefix of better-auth's own HTTP surface, mounted at `/api/auth/[...all]`. */
+export const AUTH_API_PREFIX = '/api/auth'
+
+/** JSON error body used by every auth rejection the middleware produces. */
+export function jsonAuthError(
+  message: string,
+  status: number,
+  extraHeaders?: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify({ error: message }), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  })
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,7 @@ import { betterAuth } from 'better-auth'
 import { drizzleAdapter } from '@better-auth/drizzle-adapter'
 import { admin, twoFactor } from 'better-auth/plugins'
 import { passkey } from '@better-auth/passkey'
+import { apiKey } from '@better-auth/api-key'
 import { db } from '@/db/database'
 import * as schema from '@/db/schema/auth'
 
@@ -56,6 +57,16 @@ export const auth = betterAuth({
     }),
     twoFactor({
       issuer: 'DimeTime',
+    }),
+    apiKey({
+      enableSessionForAPIKeys: true,
+      requireName: true,
+      defaultPrefix: 'dt_',
+      rateLimit: {
+        enabled: true,
+        timeWindow: 60_000,
+        maxRequests: 100,
+      },
     }),
   ],
 })

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -515,11 +515,14 @@ describe('onRequest middleware — API-Key-Verwaltung', () => {
     expect(res).toBe(nextSentinel)
   })
 
-  it('passes the request through when the session lookup throws', async () => {
-    sessionState.error = new Error('INVALID_API_KEY')
+  it('fails closed with 500 when the session lookup throws', async () => {
+    sessionState.error = new Error('SQLITE_BUSY')
     const ctx = buildContext('/api/auth/api-key/create', '', { method: 'POST' })
     const res = await onRequest(ctx, next)
-    expect(res).toBe(nextSentinel)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({
+      error: 'Sitzungsprüfung fehlgeschlagen',
+    })
   })
 
   it('does not attach locals for key-management routes', async () => {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,16 +1,21 @@
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
 import * as authSchema from '@/db/schema/auth'
 import { createTestDb } from '@/lib/__fixtures__/test-db'
+import { APIError } from 'better-auth/api'
 
 const harness = createTestDb()
 const testDb = harness.db
 
 type Session = {
-  user: { id: string; twoFactorEnabled?: boolean }
+  user: { id: string; twoFactorEnabled?: boolean; banned?: boolean | null }
   session: { id: string }
 } | null
 
-const sessionState: { value: Session } = { value: null }
+const sessionState: {
+  value: Session
+  error: unknown
+  callCount: number
+} = { value: null, error: null, callCount: 0 }
 
 void mock.module('@/db/database', () => ({
   db: testDb,
@@ -19,7 +24,11 @@ void mock.module('@/db/database', () => ({
 void mock.module('@/lib/auth', () => ({
   auth: {
     api: {
-      getSession: async () => sessionState.value,
+      getSession: async () => {
+        sessionState.callCount += 1
+        if (sessionState.error !== null) throw sessionState.error
+        return sessionState.value
+      },
     },
   },
 }))
@@ -40,9 +49,16 @@ const { onRequest } = (await import('./middleware')) as unknown as {
   ) => Promise<Response>
 }
 
-function buildContext(pathname: string, search = '') {
+function buildContext(
+  pathname: string,
+  search = '',
+  init: { method?: string; headers?: Record<string, string> } = {},
+) {
   const url = new URL(`http://test.local${pathname}${search}`)
-  const request = new Request(url.toString(), { method: 'GET' })
+  const request = new Request(url.toString(), {
+    method: init.method ?? 'GET',
+    headers: init.headers,
+  })
   const locals: Record<string, unknown> = {}
   const redirect = (path: string) =>
     new Response(null, { status: 302, headers: { Location: path } })
@@ -54,6 +70,8 @@ const next = () => nextSentinel
 
 beforeEach(async () => {
   sessionState.value = null
+  sessionState.error = null
+  sessionState.callCount = 0
   harness.reset()
   await testDb.insert(authSchema.user).values({
     id: 'u-1',
@@ -64,15 +82,24 @@ beforeEach(async () => {
   })
 })
 
-afterEach(() => {
-  sessionState.value = null
-})
-
 describe('onRequest middleware', () => {
   it('bypasses /api/auth/* without session check', async () => {
     const ctx = buildContext('/api/auth/sign-in')
     const res = await onRequest(ctx, next)
     expect(res).toBe(nextSentinel)
+  })
+
+  it('bypasses other /api/auth/* routes without any session check', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: false },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/api/auth/two-factor/verify-totp', '', {
+      method: 'POST',
+    })
+    const res = await onRequest(ctx, next)
+    expect(res).toBe(nextSentinel)
+    expect(sessionState.callCount).toBe(0)
   })
 
   it('redirects /login to / when session exists', async () => {
@@ -180,5 +207,329 @@ describe('onRequest middleware', () => {
     expect(
       (ctx.locals.userSettings as { themePreference: string }).themePreference,
     ).toBe('dark')
+  })
+})
+
+describe('onRequest middleware — API-Key-Requests', () => {
+  const apiKeyHeaders = { 'x-api-key': 'dt_test-key' }
+
+  it('allows GET /api/* with a valid key and bypasses the 2FA gate', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: false },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/api/transactions', '', {
+      headers: apiKeyHeaders,
+    })
+    const res = await onRequest(ctx, next)
+    expect(res).toBe(nextSentinel)
+    expect(ctx.locals.user).toEqual({ id: 'u-1', twoFactorEnabled: false })
+    expect(ctx.locals.session).toEqual({ id: 's-1' })
+    // Settings are only read while rendering a page, which a key can never do.
+    expect(ctx.locals.userSettings).toBeUndefined()
+  })
+
+  for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+    it(`rejects ${method} /api/* with 403 without checking the session`, async () => {
+      sessionState.value = {
+        user: { id: 'u-1', twoFactorEnabled: true },
+        session: { id: 's-1' },
+      }
+      const ctx = buildContext('/api/transactions', '', {
+        method,
+        headers: apiKeyHeaders,
+      })
+      const res = await onRequest(ctx, next)
+      expect(res.status).toBe(403)
+      expect(await res.json()).toEqual({
+        error: 'API-Schlüssel erlauben nur Lesezugriff',
+      })
+      expect(sessionState.callCount).toBe(0)
+    })
+  }
+
+  it('rejects POST /api/auth/api-key/create with 403 (keys cannot manage keys)', async () => {
+    const ctx = buildContext('/api/auth/api-key/create', '', {
+      method: 'POST',
+      headers: apiKeyHeaders,
+    })
+    const res = await onRequest(ctx, next)
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({
+      error: 'API-Schlüssel erlauben nur Lesezugriff',
+    })
+    expect(sessionState.callCount).toBe(0)
+  })
+
+  for (const { label, error, status, message, retryAfter } of [
+    {
+      label: 'returns 401 when the session lookup throws for an invalid key',
+      // Shape thrown by the api-key plugin for an unknown/disabled/expired key.
+      error: () =>
+        APIError.from('UNAUTHORIZED', {
+          code: 'INVALID_API_KEY',
+          message: 'Invalid API key.',
+        }),
+      status: 401,
+      message: 'Ungültiger API-Schlüssel',
+      retryAfter: null,
+    },
+    {
+      label: 'returns 429 with Retry-After when the key hits the rate limit',
+      // Shape thrown by the plugin's `consumeRateLimit` deny branch.
+      error: () =>
+        new APIError('TOO_MANY_REQUESTS', {
+          message: 'Rate limit exceeded. Try again later.',
+          code: 'RATE_LIMITED',
+          details: { tryAgainIn: 42_000 },
+        }),
+      status: 429,
+      message: 'Zu viele Anfragen',
+      retryAfter: '42',
+    },
+    {
+      label: 'rounds sub-second retry hints up to one second',
+      error: () =>
+        new APIError('TOO_MANY_REQUESTS', {
+          message: 'Rate limit exceeded. Try again later.',
+          code: 'RATE_LIMITED',
+          details: { tryAgainIn: 120 },
+        }),
+      status: 429,
+      message: 'Zu viele Anfragen',
+      retryAfter: '1',
+    },
+    {
+      label: 'returns 429 without Retry-After when the quota is exhausted',
+      // `remaining === 0` throws TOO_MANY_REQUESTS without retry details.
+      error: () =>
+        APIError.from('TOO_MANY_REQUESTS', {
+          code: 'USAGE_EXCEEDED',
+          message: 'API Key has reached their request limit.',
+        }),
+      status: 429,
+      message: 'Zu viele Anfragen',
+      retryAfter: null,
+    },
+    {
+      label: 'returns 500 when the session lookup fails unexpectedly',
+      error: () => new Error('database is locked'),
+      status: 500,
+      message: 'Interner Serverfehler',
+      retryAfter: null,
+    },
+    {
+      label:
+        'returns 500 for a server-side APIError instead of masking it as 401',
+      error: () =>
+        APIError.from('INTERNAL_SERVER_ERROR', {
+          code: 'FAILED_TO_UPDATE_API_KEY',
+          message: 'Failed to update API key.',
+        }),
+      status: 500,
+      message: 'Interner Serverfehler',
+      retryAfter: null,
+    },
+  ] as const) {
+    it(label, async () => {
+      sessionState.error = error()
+      const ctx = buildContext('/api/transactions', '', {
+        headers: apiKeyHeaders,
+      })
+      const res = await onRequest(ctx, next)
+      expect(res.status).toBe(status)
+      expect(await res.json()).toEqual({ error: message })
+      expect(res.headers.get('Retry-After')).toBe(retryAfter)
+      expect(ctx.locals.user).toBeUndefined()
+      expect(ctx.locals.session).toBeUndefined()
+    })
+  }
+
+  it('returns 401 when the session lookup resolves to null', async () => {
+    sessionState.value = null
+    const ctx = buildContext('/api/transactions', '', {
+      headers: apiKeyHeaders,
+    })
+    const res = await onRequest(ctx, next)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Ungültiger API-Schlüssel' })
+  })
+
+  it('rejects page routes with 403', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: true },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/plans', '', { headers: apiKeyHeaders })
+    const res = await onRequest(ctx, next)
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({
+      error: 'API-Schlüssel sind nur für API-Endpunkte gültig',
+    })
+    expect(sessionState.callCount).toBe(0)
+  })
+
+  for (const [label, value] of [
+    ['empty', ''],
+    ['whitespace-only', '   '],
+  ] as const) {
+    it(`treats an ${label} x-api-key header as absent and keeps the 2FA gate for cookie sessions`, async () => {
+      sessionState.value = {
+        user: { id: 'u-1', twoFactorEnabled: false },
+        session: { id: 's-1' },
+      }
+      const ctx = buildContext('/api/transactions', '', {
+        headers: { 'x-api-key': value },
+      })
+      const res = await onRequest(ctx, next)
+      expect(res.status).toBe(403)
+      expect(await res.json()).toEqual({
+        error: '2FA-Einrichtung erforderlich',
+      })
+      expect(ctx.locals.user).toBeUndefined()
+    })
+  }
+
+  it('returns 401 for an empty x-api-key header without any session', async () => {
+    sessionState.value = null
+    const ctx = buildContext('/api/transactions', '', {
+      headers: { 'x-api-key': '' },
+    })
+    const res = await onRequest(ctx, next)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Nicht autorisiert' })
+  })
+
+  it('does not route blank-key page requests into the API-key path', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: true },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/plans', '', { headers: { 'x-api-key': '' } })
+    const res = await onRequest(ctx, next)
+    expect(res).toBe(nextSentinel)
+    expect(ctx.locals.user).toEqual({ id: 'u-1', twoFactorEnabled: true })
+  })
+
+  it('rejects a key whose user is banned with 403 and attaches no locals', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: true, banned: true },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/api/transactions', '', {
+      headers: apiKeyHeaders,
+    })
+    const res = await onRequest(ctx, next)
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({ error: 'Benutzerkonto ist gesperrt' })
+    expect(ctx.locals.user).toBeUndefined()
+    expect(ctx.locals.session).toBeUndefined()
+    expect(ctx.locals.userSettings).toBeUndefined()
+  })
+
+  for (const [label, banned] of [
+    ['banned: false', false],
+    ['banned: null', null],
+  ] as const) {
+    it(`allows a key whose user has ${label}`, async () => {
+      sessionState.value = {
+        user: { id: 'u-1', twoFactorEnabled: false, banned },
+        session: { id: 's-1' },
+      }
+      const ctx = buildContext('/api/transactions', '', {
+        headers: apiKeyHeaders,
+      })
+      const res = await onRequest(ctx, next)
+      expect(res).toBe(nextSentinel)
+      expect(ctx.locals.user).toEqual({
+        id: 'u-1',
+        twoFactorEnabled: false,
+        banned,
+      })
+      expect(ctx.locals.session).toEqual({ id: 's-1' })
+    })
+  }
+
+  it('allows a key whose session carries no banned field at all', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: false },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/api/accounts', '', { headers: apiKeyHeaders })
+    const res = await onRequest(ctx, next)
+    expect(res).toBe(nextSentinel)
+    expect(ctx.locals.user).toEqual({ id: 'u-1', twoFactorEnabled: false })
+  })
+
+  it('rejects GET /api/auth/api-key/list with 403', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: true },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/api/auth/api-key/list', '', {
+      headers: apiKeyHeaders,
+    })
+    const res = await onRequest(ctx, next)
+    expect(res.status).toBe(403)
+    expect(await res.json()).toEqual({
+      error: 'API-Schlüssel sind nur für API-Endpunkte gültig',
+    })
+    expect(sessionState.callCount).toBe(0)
+  })
+})
+
+describe('onRequest middleware — API-Key-Verwaltung', () => {
+  for (const [method, pathname] of [
+    ['POST', '/api/auth/api-key/create'],
+    ['GET', '/api/auth/api-key/list'],
+    ['POST', '/api/auth/api-key/delete'],
+  ] as const) {
+    it(`blocks ${method} ${pathname} for a cookie session without 2FA`, async () => {
+      sessionState.value = {
+        user: { id: 'u-1', twoFactorEnabled: false },
+        session: { id: 's-1' },
+      }
+      const ctx = buildContext(pathname, '', { method })
+      const res = await onRequest(ctx, next)
+      expect(res.status).toBe(403)
+      expect(await res.json()).toEqual({
+        error: '2FA-Einrichtung erforderlich',
+      })
+    })
+
+    it(`allows ${method} ${pathname} for a cookie session with 2FA`, async () => {
+      sessionState.value = {
+        user: { id: 'u-1', twoFactorEnabled: true },
+        session: { id: 's-1' },
+      }
+      const ctx = buildContext(pathname, '', { method })
+      const res = await onRequest(ctx, next)
+      expect(res).toBe(nextSentinel)
+    })
+  }
+
+  it('passes unauthenticated key-management calls to better-auth', async () => {
+    sessionState.value = null
+    const ctx = buildContext('/api/auth/api-key/create', '', { method: 'POST' })
+    const res = await onRequest(ctx, next)
+    expect(res).toBe(nextSentinel)
+  })
+
+  it('passes the request through when the session lookup throws', async () => {
+    sessionState.error = new Error('INVALID_API_KEY')
+    const ctx = buildContext('/api/auth/api-key/create', '', { method: 'POST' })
+    const res = await onRequest(ctx, next)
+    expect(res).toBe(nextSentinel)
+  })
+
+  it('does not attach locals for key-management routes', async () => {
+    sessionState.value = {
+      user: { id: 'u-1', twoFactorEnabled: true },
+      session: { id: 's-1' },
+    }
+    const ctx = buildContext('/api/auth/api-key/list')
+    await onRequest(ctx, next)
+    expect(ctx.locals.user).toBeUndefined()
+    expect(ctx.locals.session).toBeUndefined()
   })
 })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -57,18 +57,20 @@ async function attachAuthenticatedLocals(
  * better-auth's own key endpoints only require a session, so without this check
  * a password-authenticated user who has not set up 2FA yet could mint a key and
  * then read financial data through the deliberately 2FA-exempt key path.
- * Unauthenticated requests are passed through so better-auth still answers with
- * its own 401.
+ * Unauthenticated requests (successful lookup, no session) are passed through
+ * so better-auth still answers with its own 401. A *failed* lookup however must
+ * fail closed: treating it as "no session" would let a session slip past this
+ * gate whenever the lookup errors transiently (e.g. SQLite lock).
  */
 async function handleApiKeyManagementRoute(
   context: MiddlewareContext,
   next: MiddlewareNext,
 ) {
-  let session: Session | null = null
+  let session: Session | null
   try {
     session = await auth.api.getSession({ headers: context.request.headers })
   } catch {
-    session = null
+    return jsonAuthError('Sitzungsprüfung fehlgeschlagen', 500)
   }
   if (!session) return next()
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,6 @@
+import { handleApiKeyRequest, hasApiKeyHeader } from '@/lib/api-key-auth'
 import { auth } from '@/lib/auth'
+import { AUTH_API_PREFIX, jsonAuthError } from '@/lib/auth-http'
 import { getAllSettings } from '@/lib/settings'
 import { defineMiddleware } from 'astro:middleware'
 
@@ -6,12 +8,7 @@ type MiddlewareContext = Parameters<Parameters<typeof defineMiddleware>[0]>[0]
 type MiddlewareNext = Parameters<Parameters<typeof defineMiddleware>[0]>[1]
 type Session = NonNullable<Awaited<ReturnType<typeof auth.api.getSession>>>
 
-function jsonAuthError(message: string, status: number): Response {
-  return new Response(JSON.stringify({ error: message }), {
-    status,
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
+const API_KEY_MANAGEMENT_PREFIX = `${AUTH_API_PREFIX}/api-key`
 
 async function handleLoginRoute(
   context: MiddlewareContext,
@@ -54,10 +51,41 @@ async function attachAuthenticatedLocals(
   context.locals.userSettings = await getAllSettings(session.user.id)
 }
 
+/**
+ * Gate for the `/api/auth/api-key/*` management endpoints.
+ *
+ * better-auth's own key endpoints only require a session, so without this check
+ * a password-authenticated user who has not set up 2FA yet could mint a key and
+ * then read financial data through the deliberately 2FA-exempt key path.
+ * Unauthenticated requests are passed through so better-auth still answers with
+ * its own 401.
+ */
+async function handleApiKeyManagementRoute(
+  context: MiddlewareContext,
+  next: MiddlewareNext,
+) {
+  let session: Session | null = null
+  try {
+    session = await auth.api.getSession({ headers: context.request.headers })
+  } catch {
+    session = null
+  }
+  if (!session) return next()
+
+  return requireTwoFactorSetup(context, context.url.pathname, session) ?? next()
+}
+
 export const onRequest = defineMiddleware(async (context, next) => {
+  if (hasApiKeyHeader(context.request)) {
+    return handleApiKeyRequest(context, next)
+  }
+
   const { pathname } = context.url
 
-  if (pathname.startsWith('/api/auth')) return next()
+  if (pathname.startsWith(API_KEY_MANAGEMENT_PREFIX)) {
+    return handleApiKeyManagementRoute(context, next)
+  }
+  if (pathname.startsWith(AUTH_API_PREFIX)) return next()
   if (pathname === '/login') return handleLoginRoute(context, next)
   if (pathname === '/2fa/verify') return next()
 

--- a/src/pages/account.astro
+++ b/src/pages/account.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import Dashboard from '@/components/Dashboard.vue'
+import ApiKeyManager from '@/components/ApiKeyManager.vue'
 import PasskeyManager from '@/components/PasskeyManager.vue'
 import PasswordChangeForm from '@/components/PasswordChangeForm.vue'
 import TwoFactorManager from '@/components/TwoFactorManager.vue'
@@ -37,6 +38,7 @@ if (latest && latest.id !== currentMonth?.id) {
       </div>
       <TwoFactorManager client:load />
       <PasskeyManager client:load />
+      <ApiKeyManager client:load />
       <PasswordChangeForm client:load />
     </div>
   </Dashboard>


### PR DESCRIPTION
Ermöglicht API-Zugriff über API-Keys, die Nutzer selbst auf der Kontoseite anlegen können — umgesetzt mit dem offiziellen `@better-auth/api-key`-Plugin.

## ⚠️ Vor dem Deployment erforderlich

Die Migration für die `apikey`-Tabelle fehlt noch. `drizzle/` enthält keine passende Datei, daher schlägt auf einer bestehenden Datenbank **jede** API-Key-Anfrage mit `no such table: apikey` fehl:

```bash
bun run db:generate && bun run db:migrate
```

Bewusst nicht ausgeführt, da Migrationen laut `CLAUDE.md` ausschließlich vom Nutzer erzeugt werden.

## Umfang

- **Lesezugriff:** Ein Key gilt für alle bestehenden `/api/*`-Routen, aber nur mit `GET`/`HEAD`/`OPTIONS`. Verändernde Methoden werden mit `403` abgewiesen.
- **Mehrere benannte Keys** pro Nutzer: anlegen, auflisten, widerrufen. Der Klartext-Key wird genau einmal nach der Erstellung angezeigt.
- **Session-Anmeldung bleibt unverändert.** Der Cookie-Pfad wird nur betreten, wenn kein nutzbarer `x-api-key`-Header vorliegt.
- Transport: `x-api-key: <key>`.

## Sicherheit

Vier blockierende Befunde aus dem Review wurden behoben:

| Befund | Behebung |
|---|---|
| Leerer `x-api-key`-Header umging das 2FA-Gate — `headers.get()` liefert `""` (≠ `null`), das Plugin ignorierte den Wert und `getSession` fiel auf das Session-Cookie zurück | Leere und reine Whitespace-Header gelten als nicht vorhanden |
| Nutzer ohne 2FA konnten über `/api/auth/api-key/create` einen Key erzeugen und damit den 2FA-freien Key-Pfad nutzen | `/api/auth/api-key/*` hinter demselben 2FA-Gate |
| Gesperrte Konten behielten Zugriff — ein Ban löscht Sessions, aber keine `apikey`-Zeilen | `banned`-Prüfung im Key-Pfad → `403` |
| Rate-Limit meldete `401` „ungültiger Key" statt `429` | Statusabhängige Zuordnung inkl. `Retry-After` |

## Prüfungen

`bun test` 646 ✓ · `bunx vitest run` 79 ✓ · `lint --type-aware` ✓ · `astro check` 0 Fehler · `vue-tsc` ✓ · `fallow` pass

Nicht end-to-end gegen einen laufenden Server verifiziert — insbesondere das Rate-Limit-Verhalten (100 Anfragen/Minute) beruht auf Plugin-Quellcode und Unit-Tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDC9Ey9mJPJaadMuJZH9YM