### PR TITLE
fix(auth): 2FA-Anmeldung reparieren — fehlende Lockout-Spalten ergänzen

### DIFF
--- a/drizzle/0019_mute_killraven.sql
+++ b/drizzle/0019_mute_killraven.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `two_factor` ADD `failed_verification_count` integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE `two_factor` ADD `locked_until` integer;

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1994 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c781c63a-2a8e-4d40-8842-326f592bd18f",
+  "prevId": "a7d585f9-80fc-40cf-a364-7e78eb15126b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "twoFactor_userId_idx": {
+          "name": "twoFactor_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bank_transaction": {
+      "name": "bank_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_import_id": {
+          "name": "first_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_import_id": {
+          "name": "last_seen_import_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_transaction_id": {
+          "name": "external_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "booking_date": {
+          "name": "booking_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_date": {
+          "name": "value_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'EUR'"
+        },
+        "original_amount_cents": {
+          "name": "original_amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_currency": {
+          "name": "original_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "counterparty": {
+          "name": "counterparty",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "booking_text": {
+          "name": "booking_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "balance_after_cents": {
+          "name": "balance_after_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "balance_currency": {
+          "name": "balance_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cardholder": {
+          "name": "cardholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_data_json": {
+          "name": "raw_data_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_assignment": {
+          "name": "plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'none'"
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_split_budget_id": {
+          "name": "pre_split_budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_split": {
+          "name": "is_split",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "import_seen_count": {
+          "name": "import_seen_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bankTransaction_sourceId_dedupeKey_idx": {
+          "name": "bankTransaction_sourceId_dedupeKey_idx",
+          "columns": [
+            "source_id",
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "bankTransaction_bookingDate_idx": {
+          "name": "bankTransaction_bookingDate_idx",
+          "columns": [
+            "booking_date"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_planId_idx": {
+          "name": "bankTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_status_idx": {
+          "name": "bankTransaction_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_externalTransactionId_idx": {
+          "name": "bankTransaction_externalTransactionId_idx",
+          "columns": [
+            "external_transaction_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_isArchived_idx": {
+          "name": "bankTransaction_isArchived_idx",
+          "columns": [
+            "is_archived"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_isSplit_idx": {
+          "name": "bankTransaction_isSplit_idx",
+          "columns": [
+            "is_split"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_budgetId_idx": {
+          "name": "bankTransaction_budgetId_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransaction_preSplitBudgetId_idx": {
+          "name": "bankTransaction_preSplitBudgetId_idx",
+          "columns": [
+            "pre_split_budget_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bank_transaction_source_id_import_source_id_fk": {
+          "name": "bank_transaction_source_id_import_source_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_first_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_first_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "first_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_last_seen_import_id_statement_import_id_fk": {
+          "name": "bank_transaction_last_seen_import_id_statement_import_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "statement_import",
+          "columnsFrom": [
+            "last_seen_import_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_plan_id_plan_id_fk": {
+          "name": "bank_transaction_plan_id_plan_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_budget_id_planned_transaction_id_fk": {
+          "name": "bank_transaction_budget_id_planned_transaction_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_pre_split_budget_id_planned_transaction_id_fk": {
+          "name": "bank_transaction_pre_split_budget_id_planned_transaction_id_fk",
+          "tableFrom": "bank_transaction",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "pre_split_budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bank_transaction_split": {
+      "name": "bank_transaction_split",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_transaction_id": {
+          "name": "bank_transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "bankTransactionSplit_bankTransactionId_idx": {
+          "name": "bankTransactionSplit_bankTransactionId_idx",
+          "columns": [
+            "bank_transaction_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransactionSplit_budgetId_idx": {
+          "name": "bankTransactionSplit_budgetId_idx",
+          "columns": [
+            "budget_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransactionSplit_planId_idx": {
+          "name": "bankTransactionSplit_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "bankTransactionSplit_isArchived_idx": {
+          "name": "bankTransactionSplit_isArchived_idx",
+          "columns": [
+            "is_archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "bank_transaction_split_bank_transaction_id_bank_transaction_id_fk": {
+          "name": "bank_transaction_split_bank_transaction_id_bank_transaction_id_fk",
+          "tableFrom": "bank_transaction_split",
+          "tableTo": "bank_transaction",
+          "columnsFrom": [
+            "bank_transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_split_budget_id_planned_transaction_id_fk": {
+          "name": "bank_transaction_split_budget_id_planned_transaction_id_fk",
+          "tableFrom": "bank_transaction_split",
+          "tableTo": "planned_transaction",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bank_transaction_split_plan_id_plan_id_fk": {
+          "name": "bank_transaction_split_plan_id_plan_id_fk",
+          "tableFrom": "bank_transaction_split",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "category": {
+      "name": "category",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "category_name_idx": {
+          "name": "category_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "category_slug_idx": {
+          "name": "category_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "import_source": {
+      "name": "import_source",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset": {
+          "name": "preset",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bank_name": {
+          "name": "bank_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_label": {
+          "name": "account_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account_identifier": {
+          "name": "account_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_plan_assignment": {
+          "name": "default_plan_assignment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'auto_month'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "importSource_preset_idx": {
+          "name": "importSource_preset_idx",
+          "columns": [
+            "preset"
+          ],
+          "isUnique": false
+        },
+        "importSource_isActive_idx": {
+          "name": "importSource_isActive_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plan": {
+      "name": "plan",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plan_date_idx": {
+          "name": "plan_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "planned_transaction": {
+      "name": "planned_transaction",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_done": {
+          "name": "is_done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_budget": {
+          "name": "is_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plannedTransaction_planId_idx": {
+          "name": "plannedTransaction_planId_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_userId_idx": {
+          "name": "plannedTransaction_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_dueDate_idx": {
+          "name": "plannedTransaction_dueDate_idx",
+          "columns": [
+            "due_date"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_categoryId_idx": {
+          "name": "plannedTransaction_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "plannedTransaction_type_idx": {
+          "name": "plannedTransaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "planned_transaction_plan_id_plan_id_fk": {
+          "name": "planned_transaction_plan_id_plan_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "plan",
+          "columnsFrom": [
+            "plan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_user_id_user_id_fk": {
+          "name": "planned_transaction_user_id_user_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "planned_transaction_category_id_category_id_fk": {
+          "name": "planned_transaction_category_id_category_id_fk",
+          "tableFrom": "planned_transaction",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "statement_import": {
+      "name": "statement_import",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_sha256": {
+          "name": "file_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preview_count": {
+          "name": "preview_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "imported_count": {
+          "name": "imported_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "statementImport_sourceId_idx": {
+          "name": "statementImport_sourceId_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "statementImport_fileSha256_idx": {
+          "name": "statementImport_fileSha256_idx",
+          "columns": [
+            "file_sha256"
+          ],
+          "isUnique": false
+        },
+        "statementImport_createdAt_idx": {
+          "name": "statementImport_createdAt_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "statement_import_source_id_import_source_id_fk": {
+          "name": "statement_import_source_id_import_source_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "import_source",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "statement_import_triggered_by_user_id_user_id_fk": {
+          "name": "statement_import_triggered_by_user_id_user_id_fk",
+          "tableFrom": "statement_import",
+          "tableTo": "user",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transaction_preset": {
+      "name": "transaction_preset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'expense'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'einmalig'"
+        },
+        "start_month": {
+          "name": "start_month",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "day_of_month": {
+          "name": "day_of_month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_budget": {
+          "name": "is_budget",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "transactionPreset_userId_idx": {
+          "name": "transactionPreset_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_categoryId_idx": {
+          "name": "transactionPreset_categoryId_idx",
+          "columns": [
+            "category_id"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_type_idx": {
+          "name": "transactionPreset_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "transactionPreset_recurrence_idx": {
+          "name": "transactionPreset_recurrence_idx",
+          "columns": [
+            "recurrence"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "transaction_preset_user_id_user_id_fk": {
+          "name": "transaction_preset_user_id_user_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transaction_preset_category_id_category_id_fk": {
+          "name": "transaction_preset_category_id_category_id_fk",
+          "tableFrom": "transaction_preset",
+          "tableTo": "category",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_setting": {
+      "name": "user_setting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "userSetting_userId_key_idx": {
+          "name": "userSetting_userId_key_idx",
+          "columns": [
+            "user_id",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_setting_user_id_user_id_fk": {
+          "name": "user_setting_user_id_user_id_fk",
+          "tableFrom": "user_setting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777632332449,
       "tag": "0018_thankful_impossible_man",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1786721639668,
+      "tag": "0019_mute_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/auth.ts
+++ b/src/db/schema/auth.ts
@@ -104,6 +104,13 @@ export const twoFactor = sqliteTable(
     secret: text('secret').notNull(),
     backupCodes: text('backup_codes').notNull(),
     verified: integer('verified', { mode: 'boolean' }).default(true).notNull(),
+    // Account-lockout bookkeeping. better-auth's two-factor plugin enables
+    // lockout by default (`accountLockout.enabled ?? true`), and every sign-in
+    // verification touches both columns before the TOTP secret is even
+    // decrypted — without them the Drizzle adapter rejects the unknown field
+    // and 2FA login fails outright.
+    failedVerificationCount: integer('failed_verification_count').default(0),
+    lockedUntil: integer('locked_until', { mode: 'timestamp_ms' }),
     userId: text('user_id')
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),

--- a/src/lib/__fixtures__/test-db.ts
+++ b/src/lib/__fixtures__/test-db.ts
@@ -26,7 +26,46 @@ const DDL = `
     "secret" text NOT NULL,
     "backup_codes" text NOT NULL,
     "verified" integer DEFAULT true NOT NULL,
+    "failed_verification_count" integer DEFAULT 0,
+    "locked_until" integer,
     "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE cascade
+  );
+
+  CREATE TABLE "session" (
+    "id" text PRIMARY KEY NOT NULL,
+    "expires_at" integer NOT NULL,
+    "token" text NOT NULL UNIQUE,
+    "created_at" integer NOT NULL,
+    "updated_at" integer NOT NULL,
+    "ip_address" text,
+    "user_agent" text,
+    "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE cascade,
+    "impersonated_by" text
+  );
+
+  CREATE TABLE "account" (
+    "id" text PRIMARY KEY NOT NULL,
+    "account_id" text NOT NULL,
+    "provider_id" text NOT NULL,
+    "user_id" text NOT NULL REFERENCES "user"("id") ON DELETE cascade,
+    "access_token" text,
+    "refresh_token" text,
+    "id_token" text,
+    "access_token_expires_at" integer,
+    "refresh_token_expires_at" integer,
+    "scope" text,
+    "password" text,
+    "created_at" integer NOT NULL,
+    "updated_at" integer NOT NULL
+  );
+
+  CREATE TABLE "verification" (
+    "id" text PRIMARY KEY NOT NULL,
+    "identifier" text NOT NULL,
+    "value" text NOT NULL,
+    "expires_at" integer NOT NULL,
+    "created_at" integer NOT NULL,
+    "updated_at" integer NOT NULL
   );
 
   CREATE TABLE "user_setting" (
@@ -191,6 +230,9 @@ const TRUNCATE_ORDER = [
   'category',
   'user_setting',
   'two_factor',
+  'verification',
+  'account',
+  'session',
   'user',
 ] as const
 

--- a/src/lib/two-factor-schema.test.ts
+++ b/src/lib/two-factor-schema.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from 'bun:test'
+import { betterAuth } from 'better-auth'
+import { drizzleAdapter } from '@better-auth/drizzle-adapter'
+import { twoFactor } from 'better-auth/plugins'
+import { createHmac } from 'node:crypto'
+import { symmetricDecrypt } from 'better-auth/crypto'
+import { setupTestDb } from './__fixtures__/test-setup'
+import * as schema from '@/db/schema/auth'
+
+/**
+ * Guards the `two_factor` Drizzle schema against better-auth's two-factor
+ * plugin.
+ *
+ * The plugin enables account lockout by default, so a sign-in verification
+ * reads and writes `failedVerificationCount` / `lockedUntil` *before* the TOTP
+ * secret is decrypted. When those columns are missing the Drizzle adapter
+ * throws `BetterAuthError: The field "..." does not exist in the schema`, and
+ * both 2FA enrollment and 2FA login fail with a 500 — nobody can log in.
+ *
+ * The lockout helpers only run on the sign-in path (`isSignIn = !session`), so
+ * the tests below deliberately verify with *only* the two-factor cookie rather
+ * than an active session — with a session they would silently skip the very
+ * code path being guarded.
+ */
+
+const db = setupTestDb()
+
+const EMAIL = 'two-factor-schema@dimetime.test'
+const PASSWORD = 'TwoFactorSchemaTest123!'
+const SECRET = 'test-two-factor-schema-secret-value'
+
+type Auth = ReturnType<typeof createAuth>
+
+function createAuth() {
+  return betterAuth({
+    database: drizzleAdapter(db, { provider: 'sqlite', schema }),
+    secret: SECRET,
+    baseURL: 'http://localhost:4321',
+    emailAndPassword: { enabled: true, minPasswordLength: 16 },
+    plugins: [twoFactor({ issuer: 'DimeTime' })],
+  })
+}
+
+/**
+ * Collapse every `set-cookie` on a response into one `Cookie` request header.
+ * `Headers.get('set-cookie')` only yields the first, which silently drops the
+ * two-factor challenge cookie.
+ */
+function cookiesFrom(headers: Headers): Headers {
+  const cookie = headers
+    .getSetCookie()
+    .map((entry) => entry.split(';')[0])
+    .join('; ')
+  return new Headers({ cookie })
+}
+
+/**
+ * Current valid TOTP code for the single seeded two-factor row (RFC 6238,
+ * SHA-1, 6 digits, 30s — better-auth's defaults). Computed locally so the test
+ * needs no extra dependency.
+ *
+ * The stored secret is HMAC'd as raw UTF-8, not base32-decoded: the base32
+ * string users scan is an encoding of these bytes, not the key itself.
+ */
+async function currentCode(): Promise<string> {
+  const row = db.$client
+    .query('select secret from two_factor limit 1')
+    .get() as { secret: string }
+  const raw = await symmetricDecrypt({ key: SECRET, data: row.secret })
+
+  const counter = Buffer.alloc(8)
+  counter.writeBigInt64BE(BigInt(Math.floor(Date.now() / 1000 / 30)))
+  const digest = createHmac('sha1', Buffer.from(raw, 'utf8'))
+    .update(counter)
+    .digest()
+  const offset = digest[digest.length - 1] & 0x0f
+  const binary =
+    ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff)
+  return String(binary % 1_000_000).padStart(6, '0')
+}
+
+function failureCount(): number | null {
+  const row = db.$client
+    .query('select failed_verification_count from two_factor limit 1')
+    .get() as { failed_verification_count: number | null }
+  return row.failed_verification_count
+}
+
+/**
+ * Register a user with 2FA fully enabled, then sign in again with only the
+ * password so the returned cookie is the two-factor challenge cookie — the
+ * state a real user is in when they type their TOTP code at login.
+ */
+async function signInAwaitingSecondFactor(auth: Auth): Promise<Headers> {
+  const signUp = await auth.api.signUpEmail({
+    body: { email: EMAIL, password: PASSWORD, name: 'Two Factor Schema' },
+    returnHeaders: true,
+  })
+  const sessionHeaders = cookiesFrom(signUp.headers)
+
+  await auth.api.enableTwoFactor({
+    body: { password: PASSWORD },
+    headers: sessionHeaders,
+  })
+  // Enrollment is only committed once a first code is accepted.
+  await auth.api.verifyTOTP({
+    body: { code: await currentCode() },
+    headers: sessionHeaders,
+  })
+
+  const signIn = await auth.api.signInEmail({
+    body: { email: EMAIL, password: PASSWORD },
+    returnHeaders: true,
+  })
+  return cookiesFrom(signIn.headers)
+}
+
+describe('two_factor schema vs better-auth two-factor plugin', () => {
+  test('enrolling in 2FA does not hit a missing schema field', async () => {
+    const auth = createAuth()
+    const signUp = await auth.api.signUpEmail({
+      body: { email: EMAIL, password: PASSWORD, name: 'Two Factor Schema' },
+      returnHeaders: true,
+    })
+    const headers = cookiesFrom(signUp.headers)
+
+    const enabled = await auth.api.enableTwoFactor({
+      body: { password: PASSWORD },
+      headers,
+    })
+
+    expect(enabled.totpURI).toContain('otpauth://totp/')
+  })
+
+  test('a correct code at sign-in clears the lockout counter', async () => {
+    const auth = createAuth()
+    const challengeHeaders = await signInAwaitingSecondFactor(auth)
+
+    // assertTwoFactorNotLocked runs before the secret is decrypted, and
+    // resetTwoFactorFailures runs right after the code is accepted. Both touch
+    // the lockout columns.
+    const verified = await auth.api.verifyTOTP({
+      body: { code: await currentCode() },
+      headers: challengeHeaders,
+    })
+
+    expect(verified.token).toBeTruthy()
+    expect(failureCount()).toBe(0)
+  })
+
+  test('a wrong code at sign-in increments the counter instead of crashing', async () => {
+    const auth = createAuth()
+    const challengeHeaders = await signInAwaitingSecondFactor(auth)
+
+    let caught: unknown
+    try {
+      await auth.api.verifyTOTP({
+        body: { code: '000000' },
+        headers: challengeHeaders,
+      })
+    } catch (error) {
+      caught = error
+    }
+
+    // A clean rejection, not the Drizzle schema crash that would surface as a
+    // 500 to the user.
+    expect(caught).toBeDefined()
+    expect(String(caught)).not.toContain('does not exist in the')
+    // recordTwoFactorFailure ran, which is only possible with the column.
+    expect(failureCount()).toBe(1)
+  })
+})


### PR DESCRIPTION
> **Dringend:** Auf `main` ist die Zwei-Faktor-Anmeldung derzeit komplett defekt. Da 2FA erzwungen wird und beide Konten sie aktiviert haben, kommt aktuell **niemand mehr in die App**.

## Symptom

Beide Endpunkte antworten mit **500**:

- `POST /api/auth/two-factor/enable` (Einrichtung)
- `POST /api/auth/two-factor/verify-totp` (Anmeldung)

```
BetterAuthError: The field "failedVerificationCount" does not exist
in the schema for the model "twoFactor"
```

## Ursache

Das Account-Lockout des `two-factor`-Plugins ist **standardmäßig aktiv** — `enabled: lockout?.enabled ?? true` in `verify-two-factor.mjs` — und `src/lib/auth.ts` übergibt keine `accountLockout`-Option. Es benötigt zwei Spalten auf `two_factor`, die das Drizzle-Schema nie deklariert hat:

| Spalte | Typ |
|---|---|
| `failed_verification_count` | integer, Default 0 |
| `locked_until` | integer (timestamp_ms) |

Bei jeder Anmeldung läuft `assertTwoFactorNotLocked` **bevor** das TOTP-Secret entschlüsselt wird, danach `resetTwoFactorFailures` bzw. `recordTwoFactorFailure`. Der Drizzle-Adapter lehnt das unbekannte Feld ab.

Eingeschleppt durch die routinemäßigen Dependency-Bumps (27.06. → 1.6.22, 13.07. → 1.6.23). Ein Downgrade ist nicht nötig — das Schema war schlicht nie nachgezogen.

## Änderungen

- `db/schema/auth.ts` — die zwei fehlenden Spalten
- `lib/__fixtures__/test-db.ts` — Spalten gespiegelt; zusätzlich fehlten die Tabellen `session`, `account` und `verification`, ohne die sich keine Auth-Flows testen lassen
- `lib/two-factor-schema.test.ts` — Integrationstest gegen das echte Plugin

Die Tests verifizieren bewusst **ohne** aktive Session, damit `isSignIn` wahr ist — mit Session überspringt das Plugin genau den Lockout-Pfad, um den es hier geht. Alle drei schlagen ohne den Schema-Fix mit dem Produktionsfehler fehl.

## Verifikation

End-to-End gegen `https://dimetime.local` mit einem Wegwerf-Nutzer (Datenbank vorher gesichert, danach wiederhergestellt):

| Schritt | Vorher | Nachher |
|---|---|---|
| `two-factor/enable` | 500 | **200** |
| `verify-totp` (Einrichtung) | — | **200** |
| `verify-totp` (Anmeldung) | 500 | **200**, landet auf `/` |
| Server-Fehler im Log | `BetterAuthError` | **0** |

`failed_verification_count` wurde nach erfolgreicher Anmeldung korrekt auf `0` gesetzt — der Lockout-Pfad lief also wirklich.

`bun test` 609 ✓ · `vitest` 73 ✓ · `lint --type-aware` ✓ · `astro check` 0 Fehler · `vue-tsc` ✓ · `fallow` pass

## Vor dem Deployment

```bash
bun run db:generate && bun run db:migrate
```

Unabhängig von #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDC9Ey9mJPJaadMuJZH9YM